### PR TITLE
ui: landing page revamp — black + restrained purple, tighter radii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,15 @@ Gemfile.lock
 # NPM Modules
 node_modules
 
+# Local agent / tool artifacts
+.claude/
+.playwright-mcp/
+
+# Local screenshot artifacts from design iteration
+/*.png
+!public/**/*.png
+!src/**/*.png
+
 # Gems
 *.gem
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm install              # install deps
+npm run dev              # Vite dev server (SPA only — does NOT generate blog HTML)
+npm run lint             # ESLint, --max-warnings 0
+npm run preview          # preview the built dist/
+
+# Build pipeline (each step can be run individually)
+npm run generate:blog-list   # scan public/blog/*.md → src/utils/blogList.json
+npm run build:sitemap        # scripts/generate-sitemap.js → public/sitemap.xml
+npm run build:blog           # markdown → dist/blogs/*.html AND dist/blog/<slug>/index.html, then fix-html-descriptions.js
+npm run validate:blogs       # SEO compliance gate; ❌ on errors, ⚠️ on warnings (see VALIDATION.md)
+npm run prerender            # SSR marketing routes from scripts/prerender-routes.tsx (needs vite build first)
+
+npm run build                # full pipeline: generate:blog-list → build:sitemap → build:blog → validate:blogs → tsc → vite build → prerender
+```
+
+There is no test runner configured. CI (`.github/workflows/validate-blogs.yml`) only runs `validate:blogs` on PRs that touch `public/blog/**` or the blog scripts.
+
+## Architecture
+
+Vite + React 18 + TypeScript SPA marketing site deployed on Vercel. The non-obvious complexity is the blog pipeline and the dual prerendering strategy — most pages are React-rendered into static HTML at build time, while blog posts are generated *outside* of React directly from markdown.
+
+### Three rendering paths
+
+1. **Marketing pages** (`/`, `/pricing`, `/about`, etc.) — `scripts/prerender-routes.tsx` mounts `<App>` under `StaticRouter` with `react-helmet-async`, serializes to HTML, and writes `dist/<route>/index.html`. Requires `dist/.vite/manifest.json` from `vite build` to wire up CSS/JS chunks. The `routesToPrerender` list in that script must be kept in sync with `App.tsx` routes and `vercel.json` rewrites.
+2. **Blog posts via clean URL** (`/blog/<slug>`) — `dist/blog/<slug>/index.html` written by `scripts/build-blog-html.js` directly from `public/blog/<slug>.md` using `marked` (no React on the generation path). Same file is served by Vercel rewrites; React Router also handles this path in the browser via `BlogPostDetailPage.tsx`.
+3. **Blog posts via legacy `.html` URL** (`/blogs/<Title-Case-Slug>.html`) — same generator writes a second copy to `dist/blogs/*.html`. Filenames are Title-Case-With-Hyphens; the slug→filename mapping has hand-picked overrides in `canonicalFilenameOverrides` inside `build-blog-html.js`. These files are kept for SEO/incoming links; the React app has a `/blogs/*` legacy route.
+
+### Blog data flow
+
+`public/blog/*.md` (frontmatter: title/excerpt/date/category/author/keywords) is the source of truth. `generate:blog-list` parses frontmatter into `src/utils/blogList.json` which is statically imported by `src/utils/blogUtils.ts` and used to render the blog list page. The runtime React `BlogPostDetailPage` *also* `fetch()`s the raw `.md` at request time and renders with `react-markdown` — so the same content has three rendering implementations (build-blog-html.js, React Markdown, and the post-processed HTML files). Keep markdown parsing behavior aligned between `scripts/build-blog-html.js` and `BlogPostDetailPage.tsx` when changing how posts render.
+
+The `blogPosts` array hard-coded at the top of `scripts/build-blog-html.js` is *not* the full list — only ~25 curated featured posts. The script iterates `public/blog/*.md` itself, so adding a new markdown file is enough to generate HTML, but featured/highlighted posts must also be added there.
+
+### SEO is a hard constraint, not a guideline
+
+Validation gates the build. The full ruleset lives in `README.md` and `VALIDATION.md`; the enforcement code is in:
+
+- `src/utils/titleUtils.ts` — title 30-60 chars (incl. ` | AlertMend AI` suffix), H2s 50-70 chars
+- `src/utils/descriptionUtils.ts` — meta description 50-160 chars, unique per page
+- `src/utils/urlUtils.ts` — canonical URL normalization (lowercase, no trailing slash, underscores→hyphens, no query/hash)
+- `src/components/SEO.tsx` — single source of truth for meta tags via `react-helmet-async`
+- `scripts/validate-blogs.js` — fails the build if rules are violated
+- `scripts/fix-html-descriptions.js` — auto-runs after `build:blog` to repair descriptions <50 chars
+
+Watch out: the SEO base URL is **`https://www.alertmend.io`** in `src/utils/urlUtils.ts` and `src/components/SEO.tsx`, but the sitemap, robots.txt, and README quote **`https://alertmend.io`** (no `www`). Be deliberate about which you use.
+
+### Helmet wrapper
+
+`src/lib/helmet.ts` exists because `react-helmet-async` exports differently under ESM (Vite browser build) vs CommonJS (Node-side `tsx` prerender). Import `Helmet`/`HelmetProvider` from `./lib/helmet`, not from `react-helmet-async` directly, or prerender will break.
+
+### Vercel routing
+
+`vercel.json` rewrites every named route to its prerendered `<route>/index.html`. `/blog/:slug` and `/blog/:slug.html` rewrite to `/index.html` (so the React SPA handles them — the prerender does *not* cover individual blog posts; those come from the build-blog-html output served as static files alongside SPA fallback). The catch-all `/(.*)` → `/index.html` is the SPA fallback. CSP and security headers are also set here.
+
+### TypeScript projects
+
+`tsconfig.json` (app, `strict`, `noUnusedLocals`/`noUnusedParameters` on) → `tsconfig.node.json` (Vite config) and `tsconfig.prerender.json` (the prerender script). `tsc` in the build only typechecks (`noEmit: true`); Vite handles emit.
+
+## Adding a blog post
+
+1. Drop `public/blog/<slug>.md` with the frontmatter block (`title`, `excerpt` 50-160 chars, `date`, `category`, `author`, optional `keywords`).
+2. `npm run build:blog` regenerates static HTML in `dist/blog/<slug>/index.html` and `dist/blogs/<Title-Case>.html`.
+3. To feature the post on the homepage/related-posts surfaces, add an entry to the `blogPosts` array at the top of `scripts/build-blog-html.js`.
+4. `npm run validate:blogs` before committing — CI runs this on PRs that touch blog files.

--- a/src/components/layout/AmbientBackground.module.css
+++ b/src/components/layout/AmbientBackground.module.css
@@ -1,15 +1,37 @@
+/* Ambient page background.
+   Pure CSS — no images, no network requests. Two layers:
+   1. The base layer holds soft purple radial washes at corners.
+   2. A `::before` overlay paints a subtle 56px grid (purple at 5% opacity),
+      then a radial mask fades the grid to transparent toward the edges so
+      it never competes with content.
+   Fixed position so the grid feels like a paper substrate, not a moving
+   surface. GPU-cheap: it's just a couple of gradients. */
 .canvas {
   position: fixed; inset: 0; z-index: -1; pointer-events: none; overflow: hidden;
   background:
-    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(168, 85, 247, 0.12), transparent 60%),
-    radial-gradient(ellipse 60% 50% at 90% 30%, rgba(99, 102, 241, 0.08), transparent 60%),
-    radial-gradient(ellipse 50% 40% at 10% 60%, rgba(236, 72, 153, 0.06), transparent 60%),
+    /* Top-left soft violet wash */
+    radial-gradient(ellipse 55% 50% at 10% 0%, rgba(168, 85, 247, 0.10), transparent 60%),
+    /* Bottom-right deeper violet wash */
+    radial-gradient(ellipse 65% 55% at 95% 95%, rgba(124, 58, 237, 0.08), transparent 65%),
+    /* Center subtle warm-white lift so the page feels less flat */
+    radial-gradient(ellipse 60% 45% at 50% 40%, rgba(245, 243, 255, 0.5), transparent 75%),
     var(--bg);
 }
-.orb {
-  position: fixed; border-radius: 50%; filter: blur(120px); pointer-events: none; z-index: -1;
-  animation: float 20s ease-in-out infinite;
+.canvas::before {
+  content: '';
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(to right, rgba(109, 40, 217, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(109, 40, 217, 0.05) 1px, transparent 1px);
+  background-size: 56px 56px;
+  background-position: -1px -1px;
+  /* Fade the grid toward edges and the lower half so headline + content
+     have a clean reading area. Top portion gets the visible grid texture. */
+  mask-image: radial-gradient(ellipse 90% 60% at 50% 0%, #000 0%, rgba(0, 0, 0, 0.7) 40%, transparent 85%);
+  -webkit-mask-image: radial-gradient(ellipse 90% 60% at 50% 0%, #000 0%, rgba(0, 0, 0, 0.7) 40%, transparent 85%);
+  pointer-events: none;
 }
-.a { width: 520px; height: 520px; top: -100px; left: -150px; background: rgba(168, 85, 247, 0.12); }
-.b { width: 420px; height: 420px; top: 30%; right: -120px; background: rgba(99, 102, 241, 0.10); animation-delay: -7s; }
-.c { width: 380px; height: 380px; bottom: -100px; left: 40%; background: rgba(236, 72, 153, 0.08); animation-delay: -14s; }
+
+/* Legacy orb classes kept inert until the markup is cleaned up. */
+.orb { display: none; }
+.a, .b, .c { display: none; }

--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -1,14 +1,14 @@
 .footer {
-  padding: 60px 0 32px;
+  padding: 60px 0 28px;
   border-top: 1px solid var(--border);
   margin-top: 64px;
 }
 .grid {
   display: grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap: 40px;
-  margin-bottom: 40px;
+  margin-bottom: 36px;
 }
 .brandCol p {
-  font-size: 14px; color: var(--muted); margin-top: 14px; max-width: 320px; line-height: 1.55;
+  font-size: 14px; color: var(--muted); margin-top: 14px; max-width: 320px; line-height: 1.6;
 }
 
 .backedBy {
@@ -17,8 +17,8 @@
   gap: 12px;
   margin-top: 18px;
   padding: 10px 14px;
-  border-radius: 10px;
-  background: var(--bg-2, #faf5ff);
+  border-radius: 6px;
+  background: var(--bg-2);
   border: 1px solid var(--border);
   width: fit-content;
 }
@@ -50,7 +50,7 @@
 .col li a {
   font-size: 14px; color: var(--muted); transition: color 0.2s;
 }
-.col li a:hover { color: var(--accent); }
+.col li a:hover { color: var(--text); }
 .compliance {
   padding: 20px 0 24px;
   border-top: 1px solid var(--border);
@@ -75,12 +75,12 @@
   align-items: center;
   gap: 10px;
   padding: 8px 14px 8px 10px;
-  border-radius: 12px;
-  background: var(--bg-2, #faf5ff);
+  border-radius: 6px;
+  background: var(--bg-2);
   border: 1px solid var(--border);
   color: var(--text);
 }
-.complianceLogo { flex-shrink: 0; border-radius: 6px; display: block; }
+.complianceLogo { flex-shrink: 0; border-radius: 4px; display: block; }
 .complianceText {
   display: flex; flex-direction: column; gap: 3px; align-items: flex-start; line-height: 1;
 }
@@ -116,7 +116,7 @@
 }
 
 .bottom {
-  padding-top: 24px; border-top: 1px solid var(--border);
+  padding-top: 22px; border-top: 1px solid var(--border);
   display: flex; justify-content: space-between; align-items: center;
   font-size: 13px; color: var(--muted); flex-wrap: wrap; gap: 12px;
 }

--- a/src/components/layout/Nav.module.css
+++ b/src/components/layout/Nav.module.css
@@ -5,15 +5,15 @@
   z-index: 50;
   backdrop-filter: blur(18px) saturate(160%);
   -webkit-backdrop-filter: blur(18px) saturate(160%);
-  background: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.78);
   border-bottom: 1px solid transparent;
   transition: background 0.2s ease, border-color 0.2s ease,
     box-shadow 0.25s ease, padding 0.2s ease;
 }
 .scrolled {
-  background: rgba(255, 255, 255, 0.92);
-  border-bottom-color: rgba(126, 34, 206, 0.12);
-  box-shadow: 0 8px 30px -18px rgba(76, 29, 149, 0.22);
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom-color: var(--border);
+  box-shadow: 0 6px 24px -18px rgba(0, 0, 0, 0.14);
 }
 
 .nav {
@@ -40,7 +40,7 @@
   color: var(--text-dim);
   letter-spacing: -0.005em;
   padding: 8px 12px;
-  border-radius: 6px;
+  border-radius: 4px;
   white-space: nowrap;
   transition: color 0.15s ease;
 }
@@ -48,13 +48,10 @@
   color: var(--text);
 }
 .linkActive {
-  color: #6b21a8;
+  color: var(--accent-deep);
 }
 
-/* ---------- CTA cluster ----------
-   Goal: a calm "Sign in"-style ghost link sitting next to one prominent
-   pill-shaped primary CTA. Both use the same height so the cluster reads
-   as a single component, not two competing buttons. */
+/* ---------- CTA cluster ---------- */
 .cta {
   display: flex;
   gap: 8px;
@@ -62,49 +59,75 @@
   flex-shrink: 0;
 }
 
-/* "Playground" CTA - lighter purple gradient, play icon, pill shape. */
+/* "Live · Playground" pill — communicates that this is the *running*
+   product, not marketing copy. Subtle purple-tinted chip with a pulsing
+   live dot. Still quieter than the primary "Book a demo" button. */
 .ctaPlayground.ctaPlayground {
-  height: 38px;
-  padding: 0 16px;
-  font-size: 13.5px;
-  font-weight: 600;
-  border-radius: 999px;
-  letter-spacing: -0.005em;
-  gap: 6px;
-  background: linear-gradient(135deg, #8b5cf6 0%, #a855f7 100%);
-  color: #ffffff;
-  -webkit-text-fill-color: #ffffff;
-  border: none;
-  box-shadow: 0 6px 18px -8px rgba(168, 85, 247, 0.55);
-}
-.ctaPlayground.ctaPlayground:hover {
-  filter: brightness(1.05);
-  box-shadow: 0 8px 22px -8px rgba(168, 85, 247, 0.65);
-  transform: none;
-}
-
-/* "Register" - quiet text link between the two pill CTAs. */
-.ctaRegister.ctaRegister {
-  height: 38px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
-  padding: 0 4px;
+  gap: 8px;
+  padding: 0 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--accent-deep);
+  background: var(--accent-soft);
+  border: 1px solid rgba(109, 40, 217, 0.22);
+  border-radius: 999px;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  transition: background 0.18s ease, border-color 0.18s ease,
+              color 0.18s ease, box-shadow 0.18s ease;
+}
+.ctaPlayground.ctaPlayground:hover {
+  background: #ddd6fe;
+  border-color: rgba(109, 40, 217, 0.42);
+  color: var(--accent-deep);
+  box-shadow: 0 6px 16px -10px rgba(109, 40, 217, 0.45);
+}
+
+.liveDot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.55);
+  animation: navLivePulse 1.6s ease-out infinite;
+  flex-shrink: 0;
+}
+@keyframes navLivePulse {
+  0%   { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.55); }
+  70%  { box-shadow: 0 0 0 6px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+.liveLabel {
+  font-size: 10px; font-weight: 800; letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #047857;
+}
+.playgroundLabel {
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+/* "Sign in" — quiet text link */
+.ctaSignIn.ctaSignIn {
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
   font-size: 13.5px;
   font-weight: 500;
   color: var(--text-dim);
   white-space: nowrap;
 }
-.ctaRegister.ctaRegister:hover {
+.ctaSignIn.ctaSignIn:hover {
   color: var(--text);
 }
-/* Reset border + heavy box-shadow on the ghost in the nav so it reads as
-   a quiet text link rather than a second button. */
 .ctaGhost.ctaGhost {
-  height: 38px;
+  height: 36px;
   padding: 0 14px;
   font-size: 13.5px;
   font-weight: 500;
-  border-radius: 999px;
+  border-radius: 6px;
   background: transparent;
   border-color: transparent;
   box-shadow: none;
@@ -117,13 +140,12 @@
   box-shadow: none;
   transform: none;
 }
-/* Pill primary that's tight, balanced and clearly the action. */
 .ctaPrimary.ctaPrimary {
-  height: 38px;
-  padding: 0 18px 0 18px;
+  height: 36px;
+  padding: 0 16px;
   font-size: 13.5px;
   font-weight: 600;
-  border-radius: 999px;
+  border-radius: 6px;
   letter-spacing: -0.005em;
   gap: 6px;
 }
@@ -135,9 +157,9 @@
 /* ---------- Hamburger (hidden on desktop) ---------- */
 .hamburger {
   display: none;
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
   background: #ffffff;
   border: 1px solid var(--border-strong);
   cursor: pointer;
@@ -146,12 +168,12 @@
   justify-content: center;
   flex-direction: column;
   gap: 5px;
-  box-shadow: 0 1px 2px rgba(76, 29, 149, 0.06);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
   transition: background 0.2s ease, border-color 0.2s ease;
 }
 .hamburger:hover {
   background: var(--bg-2);
-  border-color: rgba(126, 34, 206, 0.45);
+  border-color: #18181b;
 }
 .hamburger span {
   width: 18px;
@@ -168,7 +190,7 @@
 .scrim {
   position: fixed;
   inset: 0;
-  background: rgba(20, 5, 40, 0.45);
+  background: rgba(0, 0, 0, 0.40);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
   opacity: 0;
@@ -186,7 +208,7 @@
   width: min(86vw, 340px);
   background: #ffffff;
   border-left: 1px solid var(--border-strong);
-  box-shadow: -16px 0 50px -16px rgba(76, 29, 149, 0.25);
+  box-shadow: -16px 0 50px -16px rgba(0, 0, 0, 0.18);
   transform: translateX(100%);
   transition: transform 0.32s cubic-bezier(0.32, 0.72, 0.2, 1);
   z-index: 70;
@@ -194,8 +216,6 @@
   flex-direction: column;
   padding: 18px 18px 24px;
   gap: 12px;
-  /* When closed, make sure the off-screen panel can't intercept clicks
-     near the right edge of the viewport. */
   pointer-events: none;
   visibility: hidden;
 }
@@ -214,8 +234,8 @@
   margin-bottom: 8px;
 }
 .drawerClose {
-  width: 38px; height: 38px;
-  border-radius: 10px;
+  width: 36px; height: 36px;
+  border-radius: 6px;
   background: var(--bg-2);
   border: 1px solid var(--border-strong);
   color: var(--text-dim);
@@ -223,7 +243,7 @@
   cursor: pointer;
   transition: background 0.18s ease, color 0.18s ease;
 }
-.drawerClose:hover { background: rgba(126, 34, 206, 0.08); color: var(--text); }
+.drawerClose:hover { background: var(--surface-strong); color: var(--text); }
 
 .drawerLinks {
   display: flex;
@@ -234,14 +254,14 @@
 .drawerLinks a {
   display: block;
   padding: 12px 14px;
-  border-radius: 10px;
+  border-radius: 6px;
   font-size: 15px;
   font-weight: 500;
   color: var(--text);
   text-decoration: none;
   transition: background 0.18s ease;
 }
-.drawerLinks a:hover { background: rgba(126, 34, 206, 0.08); }
+.drawerLinks a:hover { background: var(--surface-strong); }
 
 .drawerCta {
   margin-top: auto;
@@ -254,23 +274,24 @@
 .drawerCta :global(.btn) { width: 100%; padding: 12px 18px; font-size: 14.5px; }
 
 /* ---------- Responsive ----------
-   Breakpoints:
-   - >960px : full nav (brand + links + ghost + primary)
-   - 540-960: brand + primary CTA + hamburger (links live in drawer)
-   - <540px : brand + hamburger only (CTAs live in drawer)
-*/
+   Specificity note: `.ctaPlayground.ctaPlayground` (doubled) is used at
+   desktop sizes to win against `body.alertmend-dark` selectors. The hide
+   rules below must match the doubled specificity or they get overridden. */
 @media (max-width: 1180px) {
   .links { gap: 2px; }
   .link { padding: 8px 10px; font-size: 13.5px; }
-  .ctaRegister { display: none; }
+  .ctaSignIn.ctaSignIn { display: none; }
 }
 @media (max-width: 1020px) {
   .links { display: none; }
-  .ctaGhost,
-  .ctaPlayground,
-  .ctaRegister { display: none; }
+  .ctaGhost.ctaGhost,
+  .ctaPlayground.ctaPlayground,
+  .ctaSignIn.ctaSignIn { display: none; }
   .hamburger { display: inline-flex; }
 }
 @media (max-width: 540px) {
-  .ctaPrimary { display: none; }
+  /* On the tightest widths, drop the primary CTA from the bar (it lives in
+     the drawer). Brand + hamburger only — clean and unmistakable. */
+  .ctaPrimary.ctaPrimary { display: none; }
+  .nav { padding: 12px 16px; gap: 12px; }
 }

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -5,17 +5,18 @@ import Icon from '../ui/Icon';
 import { useScrolled } from '../../hooks/useScrolled';
 import styles from './Nav.module.css';
 
+// Industry-standard structure: ~5 top-level items. Deep section anchors
+// ("AI RCAs", "MLOps") are reachable via the Platform link and by scrolling
+// — keeping them at the top level made the bar feel busy.
 const sectionLinks = [
   { hash: '#features', label: 'Platform' },
-  { hash: '#ai', label: 'AI RCAs' },
-  { hash: '#mlops', label: 'MLOps' },
-  { hash: '#integrations', label: 'Integrations' },
 ];
 
 const routeLinks = [
-  { to: '/case-studies', label: 'Case Studies' },
-  { to: '/blog', label: 'Blog' },
   { to: '/pricing', label: 'Pricing' },
+  { to: '/case-studies', label: 'Customers' },
+  { to: '/documentation', label: 'Docs' },
+  { to: '/blog', label: 'Blog' },
 ];
 
 const SIGNUP_URL = 'https://app.alertmend.io/signup';
@@ -108,18 +109,19 @@ export default function Nav() {
               href={PLAYGROUND_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className={`btn btn-primary ${styles.ctaPlayground}`}
+              className={styles.ctaPlayground}
             >
-              <Icon name="play" size={12} style={{ color: '#ffffff' }} />
-              Playground
+              <span className={styles.liveDot} aria-hidden />
+              <span className={styles.liveLabel}>Live</span>
+              <span className={styles.playgroundLabel}>Playground</span>
             </a>
             <a
               href={SIGNUP_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className={`${styles.link} ${styles.ctaRegister}`}
+              className={`${styles.link} ${styles.ctaSignIn}`}
             >
-              Register
+              Sign in
             </a>
             <a
               href={CALENDLY_URL}
@@ -190,10 +192,10 @@ export default function Nav() {
             href={PLAYGROUND_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="btn btn-primary"
+            className="btn btn-ghost"
             onClick={() => setDrawerOpen(false)}
           >
-            <Icon name="play" size={12} style={{ color: '#ffffff' }} />
+            <Icon name="play" size={12} strokeWidth={1.8} />
             Playground
           </a>
           <a
@@ -203,7 +205,7 @@ export default function Nav() {
             className="btn btn-ghost"
             onClick={() => setDrawerOpen(false)}
           >
-            Register
+            Sign in
           </a>
           <a
             href={CALENDLY_URL}

--- a/src/components/sections/AISpotlight.module.css
+++ b/src/components/sections/AISpotlight.module.css
@@ -1,11 +1,11 @@
 .section {
-  background: linear-gradient(180deg, transparent 0%, rgba(79, 70, 229, 0.05) 50%, transparent 100%);
+  background: transparent;
 }
 
 .spotlight {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 64px;
+  gap: 56px;
   align-items: start;
 }
 
@@ -14,11 +14,9 @@
 .text { padding-top: 4px; }
 .text :global(.sec-tag) { margin-bottom: 14px; }
 .h2 {
-  font-size: clamp(28px, 3.5vw, 42px); line-height: 1.1; letter-spacing: -0.025em;
+  font-size: clamp(28px, 3.4vw, 40px); line-height: 1.1; letter-spacing: -0.025em;
   font-weight: 700;
-  background: var(--grad-text);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--text);
   margin-bottom: 16px;
 }
 .p { color: var(--muted); font-size: 16px; line-height: 1.6; margin-bottom: 22px; }
@@ -26,9 +24,9 @@
 .list { display: grid; gap: 10px; margin-bottom: 24px; list-style: none; padding: 0; }
 .list li {
   display: flex; align-items: flex-start; gap: 12px;
-  padding: 12px 14px; border-radius: 12px;
+  padding: 12px 14px; border-radius: var(--radius);
   background: var(--surface); border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.15);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
   font-size: 14px; color: var(--text-dim);
 }
 .checkIco { color: var(--green); flex-shrink: 0; margin-top: 2px; }
@@ -36,16 +34,11 @@
 
 .visual {
   position: relative;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--border);
   background: #ffffff;
   box-shadow: var(--shadow-card);
-}
-.visual::before {
-  content: ''; position: absolute; inset: -30px;
-  background: radial-gradient(ellipse at center, rgba(126, 34, 206, 0.18) 0%, transparent 70%);
-  filter: blur(50px); z-index: -1;
 }
 
 .rca {
@@ -60,46 +53,39 @@
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px;
   padding: 12px 18px;
-  background: linear-gradient(
-    180deg,
-    rgba(126, 34, 206, 0.06) 0%,
-    rgba(126, 34, 206, 0.02) 100%
-  );
-  border-bottom: 1px solid rgba(126, 34, 206, 0.14);
+  background: #fafafa;
+  border-bottom: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
 }
 .agentBrand {
   display: inline-flex; align-items: center; gap: 8px;
 }
-/* AlertMend brand logo as the "AI agent" identity mark in the header.
-   Kept on its own (no chrome behind it) so the actual brand reads cleanly,
-   with a subtle pulsing drop-shadow that signals an active AI worker. */
 .agentLogo {
-  width: 24px; height: 24px;
+  width: 22px; height: 22px;
   display: block;
   flex-shrink: 0;
-  border-radius: 6px;
-  filter: drop-shadow(0 0 0 rgba(168, 85, 247, 0));
+  border-radius: 4px;
 }
 :global(.reveal.visible) .agentLogo {
   animation: agentLogoPulse 2.6s ease-in-out infinite;
 }
 @keyframes agentLogoPulse {
-  0%, 100% { filter: drop-shadow(0 1px 2px rgba(126, 34, 206, 0.18))
-                     drop-shadow(0 0 0 rgba(168, 85, 247, 0)); }
-  50%      { filter: drop-shadow(0 1px 2px rgba(126, 34, 206, 0.2))
-                     drop-shadow(0 0 8px rgba(168, 85, 247, 0.45)); }
+  0%, 100% { filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.10))
+                     drop-shadow(0 0 0 rgba(109, 40, 217, 0)); }
+  50%      { filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.12))
+                     drop-shadow(0 0 6px rgba(109, 40, 217, 0.40)); }
 }
 .agentName {
   font-family: 'Inter', system-ui, sans-serif;
   font-size: 13px; font-weight: 700;
-  color: #3b0764;
+  color: var(--text);
   letter-spacing: -0.005em;
 }
 .agentVer {
   font-family: 'JetBrains Mono', monospace;
   font-size: 9.5px; font-weight: 600;
-  color: #6b21a8;
-  background: rgba(126, 34, 206, 0.1);
+  color: var(--accent-deep);
+  background: var(--accent-soft);
   padding: 2px 6px; border-radius: 4px;
   letter-spacing: 0.04em;
 }
@@ -145,18 +131,16 @@
   margin-bottom: 18px;
 }
 
-/* Single elegant scanner: a soft purple band drifts from top to bottom of
-   the card while content streams in. Runs once, slowly, with a long
-   ease-in/out curve so it feels like ambient activity rather than a sweep. */
+/* Scanner — subtle accent band */
 .scan {
   position: absolute; left: 0; right: 0;
   top: -120px; height: 120px;
   pointer-events: none; opacity: 0; z-index: 1;
   background: linear-gradient(
     180deg,
-    rgba(168, 85, 247, 0) 0%,
-    rgba(168, 85, 247, 0.12) 50%,
-    rgba(99, 102, 241, 0) 100%
+    rgba(109, 40, 217, 0) 0%,
+    rgba(109, 40, 217, 0.10) 50%,
+    rgba(109, 40, 217, 0) 100%
   );
   filter: blur(8px);
 }
@@ -172,16 +156,16 @@
 .cluster { font-size: 10.5px; color: var(--muted); font-family: 'JetBrains Mono', monospace; }
 .badge {
   display: inline-flex; align-items: center; gap: 6px;
-  font-size: 10px; padding: 3px 8px; border-radius: 6px;
+  font-size: 10px; padding: 3px 8px; border-radius: 4px;
   font-weight: 700; letter-spacing: 0.04em;
 }
-.crit { background: rgba(220, 38, 38, 0.12); color: #b91c1c; }
-.ok { background: rgba(5, 150, 105, 0.12); color: #047857; }
+.crit { background: rgba(220, 38, 38, 0.10); color: #b91c1c; }
+.ok { background: rgba(5, 150, 105, 0.10); color: #047857; }
 
 .line { color: var(--text-dim); }
 .k { color: var(--text); }
 
-/* --------- Section head shared (icon + label + optional right-side meta) -- */
+/* --------- Section head shared --- */
 .sectionHead {
   display: flex; align-items: center; gap: 8px;
   margin-bottom: 10px;
@@ -193,28 +177,28 @@
 }
 .sectionIco {
   width: 18px; height: 18px;
-  border-radius: 5px;
+  border-radius: 4px;
   display: inline-flex; align-items: center; justify-content: center;
   flex-shrink: 0;
 }
-.sectionIcoSum  { background: rgba(126, 34, 206, 0.14); color: #6b21a8; }
-.sectionIcoEv   { background: rgba(99, 102, 241, 0.14); color: #4f46e5; }
-.sectionIcoConc { background: rgba(5, 150, 105, 0.14);  color: #047857; }
-.sectionIcoRem  { background: rgba(168, 85, 247, 0.14); color: #7e22ce; }
+.sectionIcoSum  { background: var(--accent-soft); color: var(--accent-deep); }
+.sectionIcoEv   { background: var(--surface-strong); color: var(--text-dim); }
+.sectionIcoConc { background: rgba(5, 150, 105, 0.12); color: #047857; }
+.sectionIcoRem  { background: var(--accent-soft); color: var(--accent-deep); }
 
 /* --------- Boxes --------- */
 .box {
-  margin-top: 12px; padding: 12px 14px; border-radius: 10px;
+  margin-top: 12px; padding: 12px 14px; border-radius: 6px;
 }
 .sumBox {
-  background: rgba(126, 34, 206, 0.05);
-  border: 1px solid rgba(126, 34, 206, 0.18);
+  background: var(--accent-soft);
+  border: 1px solid rgba(109, 40, 217, 0.18);
   margin-top: 14px;
 }
 .sumLabel { color: var(--accent); }
 .sumText {
   font-family: 'Inter', sans-serif; font-size: 13px;
-  color: var(--text-dim); line-height: 1.55;
+  color: var(--text); line-height: 1.55;
 }
 
 .evBox {
@@ -227,13 +211,11 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px; color: var(--muted);
   padding: 2px 7px; border-radius: 4px;
-  background: rgba(99, 102, 241, 0.08);
-  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
   letter-spacing: 0.02em;
 }
 
-/* Evidence source chips — start in "pending" state, animate to "done" green
-   in lockstep with each evidence line streaming in. */
 .evSources {
   display: flex; flex-wrap: wrap; gap: 6px;
   margin-bottom: 10px;
@@ -244,21 +226,21 @@
   font-size: 10px; font-weight: 600; letter-spacing: 0.01em;
   padding: 3px 8px 3px 6px;
   border-radius: 999px;
-  background: rgba(99, 102, 241, 0.06);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  color: rgba(75, 85, 99, 0.9);
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  color: var(--muted);
   transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 .evChipDot {
   width: 6px; height: 6px; border-radius: 50%;
-  background: rgba(99, 102, 241, 0.35);
-  box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
+  background: rgba(0, 0, 0, 0.20);
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   flex-shrink: 0;
   transition: background 0.3s ease;
 }
 .evChipDone {
-  background: rgba(5, 150, 105, 0.1);
-  border-color: rgba(5, 150, 105, 0.4);
+  background: rgba(5, 150, 105, 0.10);
+  border-color: rgba(5, 150, 105, 0.35);
   color: #047857;
 }
 .evChipDone .evChipDot {
@@ -274,8 +256,8 @@
 .evArrow { color: var(--accent); margin-right: 4px; }
 
 .concBox {
-  background: rgba(5, 150, 105, 0.06);
-  border: 1px solid rgba(5, 150, 105, 0.22);
+  background: rgba(5, 150, 105, 0.05);
+  border: 1px solid rgba(5, 150, 105, 0.18);
 }
 .concLabel { color: #047857; }
 .concText {
@@ -283,8 +265,6 @@
   color: var(--text); line-height: 1.55;
 }
 
-/* Confidence meter — sits in the conclusion section head, fills from 0%
-   to 94% during the analysis phase. */
 .conf {
   margin-left: auto;
   display: inline-flex; align-items: center; gap: 7px;
@@ -332,13 +312,12 @@
   flex-shrink: 0;
   width: 18px; height: 18px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #a855f7 0%, #6366f1 100%);
+  background: #0a0a0a;
   color: #ffffff;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 10px; font-weight: 800;
+  font-size: 10px; font-weight: 700;
   display: inline-flex; align-items: center; justify-content: center;
   margin-top: 1px;
-  box-shadow: 0 2px 6px -2px rgba(126, 34, 206, 0.4);
 }
 
 .tagRow {
@@ -347,26 +326,17 @@
 .deepTag {
   display: inline-flex; align-items: center; gap: 5px;
   font-family: 'JetBrains Mono', monospace; font-size: 10.5px;
-  padding: 5px 10px; border-radius: 6px;
-  background: var(--bg-2);
+  padding: 5px 10px; border-radius: 4px;
+  background: var(--surface-strong);
   border: 1px solid var(--border);
   color: var(--text-dim);
   font-weight: 600;
 }
-.deepTag :global(svg) { color: var(--accent); }
+.deepTag :global(svg) { color: var(--text-mute); }
 
 @media (max-width: 980px) { .spotlight { grid-template-columns: 1fr; gap: 40px; } }
 
-/* ---------- Generating-RCA streaming animation ----------
-   Each block fades + lifts in sequence once the parent .reveal becomes
-   visible, simulating the RCA being assembled in real time. The final
-   resting state matches the static design, so the layout is identical
-   after the animation finishes. */
-
-/* ------- RCA status pill: cycles through real engineering phases -------
-   The wrapper is wider to accommodate the longest phase label. Each phase
-   pill is absolutely positioned and crossfades into the next, leaving the
-   final resolved badge at the end. */
+/* ---------- Generating-RCA streaming animation ---------- */
 .rcaStatus {
   position: relative;
   display: inline-block;
@@ -383,29 +353,21 @@
 }
 .statusGen {
   display: inline-flex; align-items: center; gap: 6px;
-  background: rgba(126, 34, 206, 0.12);
-  color: #6b21a8;
+  background: var(--accent-soft);
+  color: var(--accent-deep);
 }
 .statusDot {
   width: 6px; height: 6px; border-radius: 50%;
-  background: #a855f7;
-  box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.6);
+  background: var(--accent);
+  box-shadow: 0 0 0 0 rgba(109, 40, 217, 0.55);
   animation: statusPulse 1.4s ease-out infinite;
 }
 @keyframes statusPulse {
-  0%   { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.55); }
-  70%  { box-shadow: 0 0 0 7px rgba(168, 85, 247, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0); }
+  0%   { box-shadow: 0 0 0 0 rgba(109, 40, 217, 0.50); }
+  70%  { box-shadow: 0 0 0 7px rgba(109, 40, 217, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(109, 40, 217, 0); }
 }
 
-/* Phase 1 — "Collecting evidence…": 0s → end of evidence stream.
-   Phase 2 — "Analyzing patterns…": pause before the conclusion lands.
-   Phase 3 — "Generating remediation…": while remediation streams in.
-   Final  — "RCA · 14.8s": settles in with a soft spring at the end.
-
-   Pills use a vertical slide+fade swap with a refined out-expo curve so the
-   cycling feels continuous, not jump-cut. Tighter overall timing (~6.6s
-   total) keeps it snappy without losing the deliberate "thinking" feel. */
 :global(.reveal.visible) .statusP1 {
   animation:
     statusIn  0.45s cubic-bezier(0.16, 1, 0.3, 1) 0.0s both,
@@ -438,30 +400,6 @@
   100% { opacity: 1; transform: scale(1) translateY(0); }
 }
 
-/* ------- Streamed sections (refined timing & easing) -------
-   All entries use `out-expo` (cubic-bezier(0.16, 1, 0.3, 1)) which has a
-   crisp landing without overshooting — feels controlled and intentional,
-   not bouncy.
-
-   Compressed timeline (~6.6s end-to-end):
-     0.3s  · Incident header
-     0.7s  · Executive summary
-     1.6s  · Evidence box (header + chips appear in pending state)
-     2.0s  · Evidence line 1   ↳ chip 1 flips green
-     2.5s  · Evidence line 2   ↳ chip 2 flips green   (~500ms cadence)
-     3.0s  · Evidence line 3   ↳ chip 3 flips green
-     3.5s  · Evidence line 4   ↳ chip 4 flips green
-     ↳ pause ~0.5s while status shifts to "Analyzing…"
-     4.2s  · Conclusion block
-     4.5s  · Confidence meter fills 0% → 94%  (with shimmer)
-     ↳ pause while status shifts to "Generating remediation…"
-     5.5s  · Remediation block
-     5.7s  · Remediation step 1
-     5.9s  · Remediation step 2
-     6.1s  · Remediation step 3
-     6.4s  · Deep-link tags
-     6.55s · Status flips to "RCA · 14.8s"
-*/
 :global(.reveal.visible) .streamResource,
 :global(.reveal.visible) .sumBox,
 :global(.reveal.visible) .evBox,
@@ -477,10 +415,6 @@
 :global(.reveal.visible) .remBlock       { animation-delay: 5.5s; }
 :global(.reveal.visible) .tagRow         { animation-delay: 6.4s; }
 
-/* Active-section glow: when each box first lands, its border briefly
-   illuminates with a soft purple ring, then settles back to the default.
-   This makes the "currently working" section feel alive without adding
-   chrome to finished sections. */
 :global(.reveal.visible) .sumBox  { animation: rcaStreamIn 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.7s backwards,
                                                 sectionGlow 1.2s ease-out 0.7s both; }
 :global(.reveal.visible) .evBox   { animation: rcaStreamIn 0.6s cubic-bezier(0.16, 1, 0.3, 1) 1.6s backwards,
@@ -491,14 +425,12 @@
   animation: rcaStreamIn 0.6s cubic-bezier(0.16, 1, 0.3, 1) 5.5s backwards;
 }
 @keyframes sectionGlow {
-  0%   { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0); }
-  20%  { box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.18),
-                     0 6px 24px -8px rgba(126, 34, 206, 0.35); }
-  100% { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0); }
+  0%   { box-shadow: 0 0 0 0 rgba(109, 40, 217, 0); }
+  20%  { box-shadow: 0 0 0 3px rgba(109, 40, 217, 0.14),
+                     0 6px 22px -8px rgba(109, 40, 217, 0.25); }
+  100% { box-shadow: 0 0 0 0 rgba(109, 40, 217, 0); }
 }
 
-/* Evidence lines stream in at a steady ~500ms cadence — feels like signals
-   landing rather than a CSS stagger. */
 :global(.reveal.visible) .evBox .evLine {
   animation: rcaStreamIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
@@ -507,9 +439,6 @@
 :global(.reveal.visible) .evLine:nth-of-type(3) { animation-delay: 3.0s; }
 :global(.reveal.visible) .evLine:nth-of-type(4) { animation-delay: 3.5s; }
 
-/* Source chips flip from pending purple-grey → done green in lockstep with
-   each evidence line landing. The dot blooms with a green halo on the way
-   in for a moment of "ack received" feedback. */
 :global(.reveal.visible) .evChip1,
 :global(.reveal.visible) .evChip2,
 :global(.reveal.visible) .evChip3,
@@ -521,13 +450,13 @@
 :global(.reveal.visible) .evChip3 { animation-delay: 3.0s; }
 :global(.reveal.visible) .evChip4 { animation-delay: 3.5s; }
 @keyframes chipFlip {
-  0%   { background: rgba(99, 102, 241, 0.06);
-         border-color: rgba(99, 102, 241, 0.2);
-         color: rgba(75, 85, 99, 0.9);
+  0%   { background: var(--surface-strong);
+         border-color: var(--border);
+         color: var(--muted);
          transform: translateY(0) scale(1); }
   40%  { transform: translateY(-1px) scale(1.04); }
-  100% { background: rgba(5, 150, 105, 0.1);
-         border-color: rgba(5, 150, 105, 0.4);
+  100% { background: rgba(5, 150, 105, 0.10);
+         border-color: rgba(5, 150, 105, 0.35);
          color: #047857;
          transform: translateY(0) scale(1); }
 }
@@ -536,7 +465,7 @@
 :global(.reveal.visible) .evChip3 .evChipDot { animation: chipDotFlip 0.55s cubic-bezier(0.16, 1, 0.3, 1) 3.0s both; }
 :global(.reveal.visible) .evChip4 .evChipDot { animation: chipDotFlip 0.55s cubic-bezier(0.16, 1, 0.3, 1) 3.5s both; }
 @keyframes chipDotFlip {
-  0%   { background: rgba(99, 102, 241, 0.35);
+  0%   { background: rgba(0, 0, 0, 0.20);
          box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
   40%  { background: #10b981;
          box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.32); }
@@ -544,8 +473,6 @@
          box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18); }
 }
 
-/* Confidence meter fills smoothly with a continuous in-out curve, plus a
-   moving highlight that travels across the bar as it fills. */
 :global(.reveal.visible) .confFill {
   animation: confFill 1.0s cubic-bezier(0.65, 0, 0.35, 1) 4.5s both;
 }
@@ -570,8 +497,6 @@
   to   { transform: translateX(100%); opacity: 0; }
 }
 
-/* Remediation steps stream in with a tight ~200ms cadence, fast enough to
-   feel like one continuous "writing" motion. */
 :global(.reveal.visible) .remList li {
   animation: rcaStreamIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
@@ -579,7 +504,6 @@
 :global(.reveal.visible) .remList li:nth-child(2) { animation-delay: 5.9s; }
 :global(.reveal.visible) .remList li:nth-child(3) { animation-delay: 6.1s; }
 
-/* Deep-link tags stagger in like a final flourish. */
 :global(.reveal.visible) .tagRow .deepTag {
   animation: rcaStreamIn 0.45s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
@@ -592,7 +516,6 @@
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-/* Reduced-motion: skip the entire build and show the resolved state. */
 @media (prefers-reduced-motion: reduce) {
   .scan { display: none; }
   .statusP1, .statusP2, .statusP3 { display: none; }
@@ -601,10 +524,9 @@
   .critDot { animation: none; }
   .confFill { width: 94%; }
   .confFill::after { display: none; }
-  /* All chips show as done. */
   .evChip {
-    background: rgba(5, 150, 105, 0.1);
-    border-color: rgba(5, 150, 105, 0.4);
+    background: rgba(5, 150, 105, 0.10);
+    border-color: rgba(5, 150, 105, 0.35);
     color: #047857;
   }
   .evChip .evChipDot {

--- a/src/components/sections/Features.module.css
+++ b/src/components/sections/Features.module.css
@@ -5,44 +5,47 @@
 }
 .card {
   grid-column: span 2; grid-row: span 1;
-  padding: 28px; border-radius: var(--radius-lg);
+  padding: 28px; border-radius: var(--radius);
   background: var(--surface); border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.18);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
   position: relative; overflow: hidden;
-  transition: all 0.3s;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   display: flex; flex-direction: column;
 }
 .card:hover {
-  border-color: rgba(126, 34, 206, 0.45);
-  transform: translateY(-3px);
-  box-shadow: 0 20px 50px -20px rgba(126, 34, 206, 0.35);
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px -18px rgba(0, 0, 0, 0.20);
 }
 .wide { grid-column: span 4; }
 .tall { grid-row: span 2; }
 .full { grid-column: span 6; }
 
-.icoBox {
-  width: 44px; height: 44px; border-radius: 12px;
-  background: linear-gradient(135deg, rgba(126, 34, 206, 0.12), rgba(79, 70, 229, 0.1));
-  border: 1px solid rgba(126, 34, 206, 0.22);
-  display: inline-flex; align-items: center; justify-content: center;
-  margin-bottom: 16px; color: var(--accent);
+.head {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 8px;
 }
-
-/* Brand-logo image (e.g. official Kubernetes mark) sized to fit the icoBox
-   slot without losing its native aspect ratio. */
+.ico {
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-mute);
+  flex-shrink: 0;
+  width: 18px; height: 18px;
+}
 .k8sIcoLogo {
-  width: 26px; height: 26px;
+  width: 18px; height: 18px;
   display: block;
 }
-.card h4 { font-size: 18px; font-weight: 600; letter-spacing: -0.015em; margin-bottom: 8px; color: var(--text); }
-.card p { font-size: 14px; color: var(--muted); line-height: 1.55; }
+.card h4 {
+  font-size: 16px; font-weight: 600; letter-spacing: -0.005em;
+  margin: 0; color: var(--text); line-height: 1.3;
+}
+.card p { font-size: 14px; color: var(--muted); line-height: 1.6; }
 
 .codeMono {
-  font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--accent);
+  font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--text);
   padding: 1px 6px; border-radius: 4px;
-  background: rgba(126, 34, 206, 0.08);
-  border: 1px solid rgba(126, 34, 206, 0.18);
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
 }
 
 .tagRow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: auto; padding-top: 16px; }
@@ -54,7 +57,7 @@
 }
 
 .preview {
-  margin-top: 18px; border-radius: 12px; overflow: hidden;
+  margin-top: 18px; border-radius: 8px; overflow: hidden;
   border: 1px solid var(--border);
   flex: 1; min-height: 220px;
   background: var(--bg-2);
@@ -64,9 +67,8 @@
 .previewSvg svg { width: 100%; height: 100%; display: block; }
 
 .fullInner {
-  display: grid; grid-template-columns: auto 1fr auto; gap: 24px; align-items: center;
+  display: grid; grid-template-columns: 1fr auto; gap: 24px; align-items: center;
 }
-.fullInner .icoBox { margin-bottom: 0; }
 
 @media (max-width: 980px) {
   .bento { grid-template-columns: repeat(2, 1fr); }

--- a/src/components/sections/Features.tsx
+++ b/src/components/sections/Features.tsx
@@ -39,19 +39,19 @@ const cards: Card[] = [
     tags: ['overview', 'incidents', 'copilot', 'drill-down'],
   },
   {
-    ico: <Icon name="message" size={22} />,
+    ico: <Icon name="message" size={16} strokeWidth={1.6} />,
     title: 'AlertMend AI chat',
     body: 'Ask cluster questions in plain language. Grounded in your real inventory, events, logs and metrics. Not generic suggestions.',
     tags: ['natural-language', 'grounded'],
   },
   {
-    ico: <Icon name="shieldCheck" size={22} />,
+    ico: <Icon name="shieldCheck" size={16} strokeWidth={1.6} />,
     title: 'Health rules',
     body: 'Per-cluster monitors for pods, nodes, PVCs, jobs, deploys. Severity, live state, operational toggle, without redeploying YAML.',
     tags: ['workflow-pod', 'deploy', 'availability'],
   },
   {
-    ico: <Icon name="database" size={22} />,
+    ico: <Icon name="database" size={16} strokeWidth={1.6} />,
     title: 'Kubernetes logs (SQL)',
     body: (
       <>
@@ -62,19 +62,19 @@ const cards: Card[] = [
     tags: ['sql', 'streams', 'indexed'],
   },
   {
-    ico: <Icon name="bar" size={22} />,
+    ico: <Icon name="bar" size={16} strokeWidth={1.6} />,
     title: 'Metrics & dashboards',
     body: 'Custom panels, data-source selectors, auto-refresh, persisted via the workspace API. One source of truth across teams.',
     tags: ['panels', 'workspace-api'],
   },
   {
-    ico: <Icon name="compass" size={22} />,
+    ico: <Icon name="compass" size={16} strokeWidth={1.6} />,
     title: 'API monitors',
     body: 'Synthetic HTTP(S) checks with status, body or response-value rules. 90-day uptime ribbons. Wired into incidents & escalation paths.',
     tags: ['synthetic', 'uptime', 'slack'],
   },
   {
-    ico: <Icon name="cpu" size={22} />,
+    ico: <Icon name="cpu" size={16} strokeWidth={1.6} />,
     title: 'GPU & MLOps observability',
     body: (
       <>
@@ -88,7 +88,7 @@ const cards: Card[] = [
   },
   {
     variant: 'wide',
-    ico: <Icon name="workflow" size={22} />,
+    ico: <Icon name="workflow" size={16} strokeWidth={1.6} />,
     title: 'Runbooks · visual workflows that act',
     body: 'Trigger on alerts, cron, health policy or webhooks. Run the same command across an entire VM fleet, or fan out into every pod that matches a label. Branch on output. Pause for Slack/Teams approval. Archive logs to S3, then post a closing summary to chat. Same definition, every time.',
     tags: [
@@ -104,7 +104,7 @@ const cards: Card[] = [
     ],
   },
   {
-    ico: <Icon name="dollar" size={22} />,
+    ico: <Icon name="dollar" size={16} strokeWidth={1.6} />,
     title: 'Kubernetes FinOps',
     body: (
       <>
@@ -116,7 +116,7 @@ const cards: Card[] = [
     tags: ['right-sizing', 'yaml-apply'],
   },
   {
-    ico: <Icon name="activity" size={22} />,
+    ico: <Icon name="activity" size={16} strokeWidth={1.6} />,
     title: 'AWS cost optimization',
     body: (
       <>
@@ -128,14 +128,14 @@ const cards: Card[] = [
     tags: ['ec2', 'rds', 'savings'],
   },
   {
-    ico: <Icon name="phone" size={22} />,
+    ico: <Icon name="phone" size={16} strokeWidth={1.6} />,
     title: 'On-call programs',
     body: 'Schedules & rotations with timezones. Escalation paths chain email → WhatsApp → phone with wait timers. Sustainable paging at scale.',
     tags: ['schedules', 'escalation', 'whatsapp'],
   },
   {
     variant: 'full',
-    ico: <Icon name="shield" size={22} />,
+    ico: <Icon name="shield" size={16} strokeWidth={1.6} />,
     title: 'RBAC, audit & compliance, built in',
     body: 'Granular role-based access controls scope navigation, data and mutating actions. Every page navigation, click and apply is captured in the audit trail with per-user filters and error-only views, for security reviews, break-glass checks and SoC-style separation of duties.',
     custom: (
@@ -175,9 +175,11 @@ export default function Features() {
               return (
                 <div key={i} className={`${styles.card} ${styles.full}`}>
                   <div className={styles.fullInner}>
-                    <div className={styles.icoBox}>{c.ico}</div>
                     <div>
-                      <h4 style={{ marginBottom: 4 }}>{c.title}</h4>
+                      <div className={styles.head}>
+                        <span className={styles.ico}>{c.ico}</span>
+                        <h4 style={{ marginBottom: 0 }}>{c.title}</h4>
+                      </div>
                       <p>{c.body}</p>
                     </div>
                     {c.custom}
@@ -187,8 +189,10 @@ export default function Features() {
             }
             return (
               <div key={i} className={`${styles.card} ${variantClass(c.variant)}`}>
-                <div className={styles.icoBox}>{c.ico}</div>
-                <h4>{c.title}</h4>
+                <div className={styles.head}>
+                  <span className={styles.ico}>{c.ico}</span>
+                  <h4>{c.title}</h4>
+                </div>
                 <p>{c.body}</p>
                 {c.preview && (
                   <div className={styles.preview}>

--- a/src/components/sections/FinalCTA.module.css
+++ b/src/components/sections/FinalCTA.module.css
@@ -1,36 +1,129 @@
 .final {
-  padding: 64px 56px; border-radius: var(--radius-lg);
+  padding: 72px 56px;
+  border-radius: 12px;
+  /* Deep zinc base with layered radial purple glows from top-right + bottom-left
+     and a subtle dot pattern. Reads richer than a flat black panel. */
   background:
-    radial-gradient(ellipse 60% 80% at 0% 100%, rgba(126, 34, 206, 0.18), transparent 70%),
-    radial-gradient(ellipse 60% 80% at 100% 0%, rgba(192, 38, 211, 0.14), transparent 70%),
-    linear-gradient(180deg, #ffffff, #faf5ff);
-  border: 1px solid rgba(126, 34, 206, 0.22);
-  box-shadow: 0 24px 60px -28px rgba(76, 29, 149, 0.32);
+    radial-gradient(ellipse 50% 60% at 100% 0%, rgba(168, 85, 247, 0.28), transparent 60%),
+    radial-gradient(ellipse 60% 70% at 0% 100%, rgba(109, 40, 217, 0.32), transparent 60%),
+    linear-gradient(180deg, #1a1325 0%, #0f0a1a 100%);
+  color: #ffffff;
+  border: 1px solid rgba(168, 85, 247, 0.18);
   text-align: center;
   position: relative; overflow: hidden;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.06) inset,
+    0 30px 60px -30px rgba(76, 29, 149, 0.45);
 }
-.h2 {
-  font-size: clamp(32px, 4.5vw, 52px); line-height: 1.1; letter-spacing: -0.03em; font-weight: 800;
-  background: var(--grad-text);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+/* Subtle dotted texture, low opacity, sits behind text. */
+.final::before {
+  content: '';
+  position: absolute; inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+  background-size: 22px 22px;
+  background-position: 0 0;
+  mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, #000 30%, transparent 80%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 70% at 50% 50%, #000 30%, transparent 80%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* Section tag (eyebrow) — repainted for the dark surface. */
+.final :global(.sec-tag) {
+  color: rgba(255, 255, 255, 0.65);
   position: relative;
 }
+.final :global(.sec-tag)::before {
+  background: #c4b5fd;
+  box-shadow: 0 0 0 4px rgba(196, 181, 253, 0.18);
+}
+
+.h2 {
+  font-size: clamp(32px, 4.4vw, 50px);
+  line-height: 1.08; letter-spacing: -0.03em; font-weight: 700;
+  color: #ffffff;
+  position: relative;
+  margin-top: 6px;
+}
+/* The inline `.hero-h-accent` span inside the heading lives in global.css
+   as `color: var(--accent)` — repaint it to a brighter violet for this
+   dark panel. */
+.final .h2 :global(.hero-h-accent) {
+  color: #c4b5fd;
+  background: linear-gradient(135deg, #ddd6fe 0%, #a78bfa 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .p {
-  max-width: 580px; margin: 18px auto 32px;
-  font-size: 17px; color: var(--muted); line-height: 1.55;
+  max-width: 600px; margin: 20px auto 32px;
+  font-size: 17px; color: rgba(255, 255, 255, 0.78); line-height: 1.6;
   position: relative;
 }
 .cta {
-  display: flex; gap: 14px; justify-content: center; flex-wrap: wrap;
+  display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;
   position: relative;
 }
 .meta {
-  margin-top: 24px; font-size: 13px; color: var(--muted);
-  display: flex; justify-content: center; gap: 18px; flex-wrap: wrap;
+  margin-top: 28px; font-size: 13px; color: rgba(255, 255, 255, 0.62);
+  display: flex; justify-content: center; gap: 22px; flex-wrap: wrap;
   position: relative;
 }
 .meta span { display: flex; align-items: center; gap: 6px; }
-.meta svg { color: var(--green); }
+.meta svg { color: #34d399; }
 
-@media (max-width: 980px) { .final { padding: 48px 28px; } }
+/* On the dark panel the standard light-mode .btn-primary (black on white)
+   disappears. Force the inverted treatment here. Doubled selector + body
+   prefix beats `body.alertmend-dark .btn-primary` in `global.css`. */
+:global(body.alertmend-dark) .final :global(.btn-primary),
+:global(body.alertmend-dark) .final :global(a.btn-primary),
+:global(body.alertmend-dark) .final :global(a.btn-primary:visited) {
+  background: #ffffff;
+  color: #0a0a0a;
+  -webkit-text-fill-color: #0a0a0a;
+  border-color: #ffffff;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.5) inset,
+    0 6px 20px -8px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+:global(body.alertmend-dark) .final :global(.btn-primary):hover {
+  background: #fafafa;
+  border-color: #fafafa;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 8px 24px -8px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.20);
+  transform: translateY(-1px);
+}
+:global(body.alertmend-dark) .final :global(.btn-primary) *,
+:global(body.alertmend-dark) .final :global(.btn-primary) svg,
+:global(body.alertmend-dark) .final :global(.btn-primary) svg * {
+  color: #0a0a0a;
+  -webkit-text-fill-color: #0a0a0a;
+  stroke: currentColor;
+}
+
+:global(body.alertmend-dark) .final :global(.btn-ghost),
+:global(body.alertmend-dark) .final :global(a.btn-ghost),
+:global(body.alertmend-dark) .final :global(a.btn-ghost:visited) {
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+  -webkit-text-fill-color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+:global(body.alertmend-dark) .final :global(.btn-ghost):hover {
+  background: rgba(255, 255, 255, 0.10);
+  border-color: rgba(255, 255, 255, 0.42);
+  color: #ffffff;
+}
+:global(body.alertmend-dark) .final :global(.btn-ghost) svg {
+  color: #ffffff;
+}
+
+@media (max-width: 980px) {
+  .final { padding: 52px 24px; }
+}

--- a/src/components/sections/Hero.module.css
+++ b/src/components/sections/Hero.module.css
@@ -1,31 +1,27 @@
-.hero { padding: 36px 0 48px; text-align: center; position: relative; }
+.hero { padding: 48px 0 56px; text-align: center; position: relative; }
 
 .h1 {
   margin-top: 0;
-  font-size: clamp(36px, 5.6vw, 70px);
-  line-height: 1.08; letter-spacing: -0.035em; font-weight: 800;
-  background: var(--grad-text);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  font-size: clamp(36px, 5.4vw, 64px);
+  line-height: 1.06; letter-spacing: -0.035em; font-weight: 700;
+  color: var(--text);
 }
 .row { display: inline-block; white-space: nowrap; }
 .accent {
-  background: var(--grad-primary);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--accent);
 }
 .tagline {
-  display: block; width: fit-content; margin: 20px auto 0;
-  font-size: clamp(16px, 1.5vw, 20px); font-weight: 600; letter-spacing: -0.005em;
+  display: block; width: fit-content; margin: 18px auto 0;
+  font-size: clamp(15px, 1.4vw, 18px); font-weight: 500; letter-spacing: -0.005em;
   color: var(--text-mute);
 }
 .sub {
-  max-width: 720px; margin: 24px auto 0;
-  font-size: clamp(16px, 1.4vw, 19px); color: var(--muted);
-  line-height: 1.55;
+  max-width: 720px; margin: 22px auto 0;
+  font-size: clamp(15px, 1.3vw, 18px); color: var(--muted);
+  line-height: 1.6;
 }
 .heroCta {
-  display: flex; gap: 14px; justify-content: center; margin-top: 36px; flex-wrap: wrap;
+  display: flex; gap: 12px; justify-content: center; margin-top: 32px; flex-wrap: wrap;
 }
 .heroMeta {
   margin-top: 22px; font-size: 13px; color: var(--muted);
@@ -48,8 +44,8 @@
   font-weight: 700;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--text-dim, #6b21a8);
-  opacity: 0.75;
+  color: var(--text-mute);
+  opacity: 0.8;
 }
 .complianceList {
   display: flex;
@@ -62,20 +58,20 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px 10px 12px;
-  border-radius: 14px;
+  border-radius: 8px;
   background: #ffffff;
-  border: 1px solid var(--border, rgba(126, 34, 206, 0.18));
-  box-shadow: 0 1px 2px rgba(20, 10, 40, 0.04), 0 6px 18px rgba(126, 34, 206, 0.07);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 .complianceBadge:hover {
-  transform: translateY(-2px);
-  border-color: rgba(126, 34, 206, 0.32);
-  box-shadow: 0 2px 4px rgba(20, 10, 40, 0.05), 0 12px 28px rgba(126, 34, 206, 0.12);
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05), 0 10px 22px -14px rgba(0, 0, 0, 0.18);
 }
 .complianceLogo {
   flex-shrink: 0;
-  border-radius: 8px;
+  border-radius: 6px;
   display: block;
 }
 .complianceText {
@@ -122,31 +118,26 @@
 }
 
 /* Browser mockup */
-.mockup { margin: 64px auto 0; max-width: 1100px; position: relative; }
-.mockup::before {
-  content: ''; position: absolute; inset: -40px -20px;
-  background: radial-gradient(ellipse at center, rgba(126, 34, 206, 0.18) 0%, transparent 70%);
-  filter: blur(60px); z-index: -1;
-}
+.mockup { margin: 56px auto 0; max-width: 1100px; position: relative; }
 .browser {
-  border-radius: 18px; overflow: hidden;
+  border-radius: 10px; overflow: hidden;
   background: #ffffff;
   border: 1px solid var(--border-strong);
-  box-shadow: var(--shadow-card), 0 0 0 1px rgba(126, 34, 206, 0.08);
+  box-shadow: var(--shadow-card);
 }
 .browserBar {
   display: flex; align-items: center; gap: 8px;
-  padding: 12px 16px;
-  background: var(--bg-2);
+  padding: 10px 14px;
+  background: #fafafa;
   border-bottom: 1px solid var(--border);
 }
 .dots { display: flex; gap: 6px; }
-.dots span { width: 11px; height: 11px; border-radius: 50%; background: rgba(126, 34, 206, 0.18); }
+.dots span { width: 11px; height: 11px; border-radius: 50%; background: rgba(0, 0, 0, 0.10); }
 .dots span:nth-child(1) { background: #ff5f57; }
 .dots span:nth-child(2) { background: #febc2e; }
 .dots span:nth-child(3) { background: #28c840; }
 .url {
-  flex: 1; margin-left: 16px; padding: 5px 12px; border-radius: 6px;
+  flex: 1; margin-left: 16px; padding: 5px 12px; border-radius: 4px;
   background: #ffffff;
   border: 1px solid var(--border);
   font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--muted);
@@ -158,18 +149,15 @@
 .stage {
   display: grid; grid-template-columns: 280px 1fr; gap: 18px;
   padding: 22px;
-  background:
-    radial-gradient(ellipse 600px 300px at 80% 0%, rgba(126, 34, 206, 0.08), transparent 70%),
-    radial-gradient(ellipse 500px 280px at 0% 100%, rgba(79, 70, 229, 0.07), transparent 70%),
-    linear-gradient(180deg, #ffffff 0%, #faf5ff 100%);
+  background: #fafafa;
   text-align: left;
   align-items: stretch;
 }
 .card {
   background: #ffffff;
   border: 1px solid var(--border);
-  border-radius: 14px; padding: 16px;
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.18);
+  border-radius: 8px; padding: 16px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
   display: flex; flex-direction: column;
 }
 .cardHead {
@@ -183,8 +171,8 @@
 .firingPill {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 3px 9px; border-radius: 999px; font-size: 11px; font-weight: 600;
-  background: rgba(220, 38, 38, 0.1); color: #b91c1c;
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  background: rgba(220, 38, 38, 0.08); color: #b91c1c;
+  border: 1px solid rgba(220, 38, 38, 0.25);
 }
 .firingDot {
   width: 6px; height: 6px; border-radius: 50%; background: #dc2626;
@@ -215,8 +203,8 @@
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--muted);
 }
-.tlDot[data-kind='warn'] { background: #d97706; box-shadow: 0 0 8px rgba(217, 119, 6, 0.4); }
-.tlDot[data-kind='info'] { background: var(--accent-2); box-shadow: 0 0 8px rgba(79, 70, 229, 0.4); }
+.tlDot[data-kind='warn'] { background: var(--amber); box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.15); }
+.tlDot[data-kind='info'] { background: #0a0a0a; box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.10); }
 .tlTime {
   font-family: 'JetBrains Mono', monospace; font-size: 10.5px;
   color: var(--muted);
@@ -225,7 +213,7 @@
 .tlText code {
   font-family: 'JetBrains Mono', monospace; font-size: 10.5px;
   padding: 1px 5px; border-radius: 4px;
-  background: var(--bg-2); color: var(--text);
+  background: var(--surface-strong); color: var(--text);
   border: 1px solid var(--border);
 }
 
@@ -236,7 +224,6 @@
 .metaLogo {
   width: 14px; height: 14px; flex: none; object-fit: contain;
   display: inline-block;
-  filter: drop-shadow(0 1px 2px rgba(76, 29, 149, 0.18));
 }
 .metaSource { flex-wrap: wrap; gap: 4px 6px; }
 .metaSrcItem { display: inline-flex; align-items: center; gap: 5px; }
@@ -248,22 +235,21 @@
 }
 .aiBadge {
   display: inline-flex; align-items: center; gap: 8px;
-  padding: 6px 12px; border-radius: 10px;
-  background: linear-gradient(135deg, rgba(126, 34, 206, 0.12), rgba(79, 70, 229, 0.12));
-  border: 1px solid rgba(126, 34, 206, 0.3);
-  font-size: 13px; font-weight: 700; color: var(--text);
+  padding: 6px 10px; border-radius: 6px;
+  background: var(--accent-soft);
+  border: 1px solid rgba(109, 40, 217, 0.20);
+  font-size: 12.5px; font-weight: 700; color: var(--accent-deep);
 }
 .aiIco {
   width: 18px; height: 18px;
   display: block; flex-shrink: 0;
   border-radius: 4px;
-  filter: drop-shadow(0 1px 2px rgba(126, 34, 206, 0.18));
 }
 .timer {
   display: inline-flex; align-items: center; gap: 6px;
   font-size: 12px; color: #047857; font-weight: 600;
   padding: 4px 10px; border-radius: 999px;
-  background: rgba(5, 150, 105, 0.08); border: 1px solid rgba(5, 150, 105, 0.25);
+  background: rgba(5, 150, 105, 0.08); border: 1px solid rgba(5, 150, 105, 0.22);
 }
 .steps { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
 .step {
@@ -281,20 +267,20 @@
 .step code {
   font-family: 'JetBrains Mono', monospace; font-size: 12px;
   padding: 1px 6px; border-radius: 4px;
-  background: rgba(126, 34, 206, 0.1); color: var(--accent);
-  border: 1px solid rgba(126, 34, 206, 0.18);
+  background: var(--surface-strong); color: var(--text);
+  border: 1px solid var(--border);
 }
 
 .diff {
-  background: #fafafa;
+  background: #ffffff;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 8px;
   overflow: hidden;
 }
 .diffHead {
   display: flex; align-items: center; gap: 8px;
   padding: 7px 12px;
-  background: var(--bg-2);
+  background: #fafafa;
   border-bottom: 1px solid var(--border);
   font-size: 11.5px;
 }
@@ -306,8 +292,8 @@
 }
 .diffBadge {
   font-size: 10px; padding: 2px 8px; border-radius: 999px;
-  background: rgba(126, 34, 206, 0.12); color: var(--accent);
-  border: 1px solid rgba(126, 34, 206, 0.3);
+  background: var(--surface-strong); color: var(--text-dim);
+  border: 1px solid var(--border);
   font-weight: 600; letter-spacing: 0.02em; flex: none;
 }
 .diffBody {
@@ -318,20 +304,21 @@
   white-space: pre; overflow-x: auto;
   background: #ffffff;
 }
-.diffMinus { color: #b91c1c; background: rgba(220, 38, 38, 0.07); margin: 0 -12px; padding: 0 12px; }
-.diffPlus { color: #047857; background: rgba(5, 150, 105, 0.08); margin: 0 -12px; padding: 0 12px; }
+.diffMinus { color: #b91c1c; background: rgba(220, 38, 38, 0.06); margin: 0 -12px; padding: 0 12px; }
+.diffPlus { color: #047857; background: rgba(5, 150, 105, 0.07); margin: 0 -12px; padding: 0 12px; }
 
 .result {
-  background: linear-gradient(180deg, rgba(126, 34, 206, 0.06), rgba(79, 70, 229, 0.04));
-  border: 1px solid rgba(126, 34, 206, 0.25);
-  border-radius: 12px; padding: 14px 16px;
+  background: #fafafa;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px; padding: 14px 16px;
 }
 .resultLabel {
   font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
   color: var(--accent); margin-bottom: 6px;
 }
 .resultText {
-  font-size: 14px; color: var(--text); line-height: 1.5; font-weight: 500;
+  font-size: 14px; color: var(--text); line-height: 1.55; font-weight: 500;
 }
 .resultText code {
   font-family: 'JetBrains Mono', monospace; font-size: 12.5px;
@@ -342,7 +329,7 @@
   font-size: 12px; color: var(--muted);
 }
 .confBar {
-  flex: 1; height: 6px; border-radius: 999px; background: rgba(126, 34, 206, 0.1);
+  flex: 1; height: 5px; border-radius: 999px; background: rgba(0, 0, 0, 0.08);
   overflow: hidden;
 }
 .confBar span {
@@ -355,8 +342,8 @@
 .actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .act {
   display: inline-flex; align-items: center; gap: 8px;
-  padding: 9px 13px;
-  border-radius: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
   font-size: 13px; font-weight: 600;
   letter-spacing: -0.005em;
   border: 1px solid var(--border-strong);
@@ -364,30 +351,26 @@
   transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
 }
 /* All three action chips are peers: the row is a *demo* of what the
-   platform does, not a CTA bar.  Real "click me" buttons are the Hero
+   platform does, not a CTA bar. Real "click me" buttons are the Hero
    CTAs ("Book a demo" / "See it in action") above. */
 .actGhost {
   background: #ffffff;
   color: var(--text);
-  box-shadow: 0 1px 2px rgba(20, 10, 40, 0.05);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
 }
 .actGhost:hover {
-  border-color: var(--accent-soft, #d8b4fe);
-  box-shadow: 0 4px 14px rgba(126, 34, 206, 0.10);
+  border-color: #18181b;
 }
-/* Icon container for action chips.  Each action gets a small tinted
-   plate around its logo so the row reads as a sequence of well-formed
-   actions rather than three loose chips. */
 .actIcoBox {
   width: 18px; height: 18px;
-  border-radius: 5px;
+  border-radius: 4px;
   display: inline-flex; align-items: center; justify-content: center;
   flex: none;
-  background: #f5f3ff;
-  color: var(--accent);
+  background: var(--surface-strong);
+  color: var(--text);
 }
 .actIcoBoxGh {
-  background: #f1f5f9;
+  background: #f4f4f5;
   color: #0f172a;
 }
 .actIcoBoxPlay {
@@ -396,7 +379,7 @@
 }
 .actIcoBoxSlack {
   background: #ffffff;
-  border: 1px solid #f1f5f9;
+  border: 1px solid var(--border);
 }
 .actIcoBox svg { width: 11px; height: 11px; }
 .actIcoBox .actLogo { width: 12px; height: 12px; }
@@ -406,6 +389,18 @@
 @media (max-width: 720px) {
   .stage { grid-template-columns: 1fr; min-height: 0; padding: 16px; gap: 14px; }
 }
+@media (max-width: 640px) {
+  /* Allow the H1 to wrap naturally; nowrap rows blow past the viewport. */
+  .row { white-space: normal; display: inline; }
+  .h1 { font-size: clamp(30px, 9vw, 44px); line-height: 1.1; }
+  .sub { font-size: 15px; }
+  /* Meta row: stack vertically; the inline `·` separator spans (every other
+     child) become noise across multiple lines, so hide them. */
+  .heroMeta { flex-direction: column; gap: 8px; align-items: center; }
+  .heroMeta > span:nth-child(2n) { display: none; }
+}
 @media (max-width: 540px) {
   .heroCta { flex-direction: column; align-items: stretch; }
+  .hero { padding: 32px 0 40px; }
+  .mockup { margin-top: 36px; }
 }

--- a/src/components/sections/HowItWorks.module.css
+++ b/src/components/sections/HowItWorks.module.css
@@ -4,19 +4,24 @@
 .step {
   padding: 28px 24px; border-radius: var(--radius);
   background: var(--surface); border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.16);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
   position: relative;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+.step:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.18);
 }
 .num {
   position: absolute; top: -12px; left: 24px;
-  width: 28px; height: 28px; border-radius: 8px;
-  background: var(--grad-primary); color: #fff;
+  width: 26px; height: 26px; border-radius: 6px;
+  background: #0a0a0a; color: #fff;
   display: inline-flex; align-items: center; justify-content: center;
-  font-size: 13px; font-weight: 700;
-  box-shadow: 0 6px 20px -4px rgba(126, 34, 206, 0.45);
+  font-size: 12px; font-weight: 700;
 }
 .step h4 { font-size: 16px; font-weight: 600; margin: 8px 0 8px; color: var(--text); }
-.step p { font-size: 13px; color: var(--muted); line-height: 1.55; }
+.step p { font-size: 13px; color: var(--muted); line-height: 1.6; }
 
 @media (max-width: 980px) { .flow { grid-template-columns: 1fr 1fr; } }
 @media (max-width: 540px) { .flow { grid-template-columns: 1fr; } }

--- a/src/components/sections/Integrations.module.css
+++ b/src/components/sections/Integrations.module.css
@@ -5,18 +5,17 @@
 .cell {
   aspect-ratio: 1.6 / 1;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px;
-  padding: 10px 6px; border-radius: 10px;
+  padding: 10px 6px; border-radius: 6px;
   background: var(--surface); border: 1px solid var(--border);
-  box-shadow: 0 2px 10px -6px rgba(76, 29, 149, 0.18);
-  transition: all 0.2s;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
-.cell:hover { background: var(--bg-2); border-color: rgba(126, 34, 206, 0.3); transform: translateY(-2px); }
+.cell:hover { background: #fafafa; border-color: var(--border-strong); transform: translateY(-1px); }
 .logoChip {
-  width: 28px; height: 28px; border-radius: 7px;
+  width: 28px; height: 28px; border-radius: 5px;
   background: #ffffff;
   display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid var(--border);
-  box-shadow: 0 2px 6px -4px rgba(76, 29, 149, 0.2);
 }
 .logoImg { width: 18px; height: 18px; object-fit: contain; display: block; }
 .cell span { font-size: 10.5px; color: var(--text-dim); font-weight: 500; line-height: 1.2; text-align: center; }

--- a/src/components/sections/MLOps.module.css
+++ b/src/components/sections/MLOps.module.css
@@ -1,5 +1,5 @@
 .section {
-  background: linear-gradient(180deg, transparent 0%, rgba(126, 34, 206, 0.04) 50%, transparent 100%);
+  background: transparent;
 }
 
 /* ---- Boards row ---- */
@@ -8,25 +8,19 @@
 }
 .board {
   display: flex; flex-direction: column;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   background: #ffffff;
   border: 1px solid var(--border);
   overflow: hidden;
-  box-shadow: 0 16px 50px -24px rgba(76, 29, 149, 0.22);
+  box-shadow: var(--shadow-card);
   position: relative;
-}
-.board::before {
-  content: ''; position: absolute; inset: -30px -10px auto;
-  height: 80px;
-  background: radial-gradient(ellipse at top, rgba(126, 34, 206, 0.10), transparent 70%);
-  filter: blur(30px); z-index: 0; pointer-events: none;
 }
 
 .boardHead {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 18px 20px;
+  padding: 16px 18px;
   border-bottom: 1px solid var(--border);
-  background: var(--bg-2);
+  background: #fafafa;
   position: relative; z-index: 1;
   gap: 16px;
 }
@@ -35,7 +29,7 @@
   min-width: 0;
   flex: 1 1 auto;
 }
-/* The inner anonymous div that holds .boardTitle + .boardSub.  Needs
+/* The inner anonymous div that holds .boardTitle + .boardSub. Needs
    min-width: 0 so its children's text-overflow: ellipsis can engage,
    otherwise long subtitles push into the status pill. */
 .boardTitleWrap > div {
@@ -43,7 +37,9 @@
   flex: 1 1 auto;
 }
 .boardIco {
-  width: 32px; height: 32px; border-radius: 9px;
+  width: 28px; height: 28px; border-radius: 6px;
+  background: var(--surface-strong);
+  color: var(--text-mute);
   display: inline-flex; align-items: center; justify-content: center;
   flex-shrink: 0;
 }
@@ -67,18 +63,18 @@
 }
 .pillOk {
   color: #047857;
-  background: rgba(5, 150, 105, 0.1);
-  border: 1px solid rgba(5, 150, 105, 0.3);
+  background: rgba(5, 150, 105, 0.08);
+  border: 1px solid rgba(5, 150, 105, 0.22);
 }
 .pillWarn {
   color: #b45309;
-  background: rgba(217, 119, 6, 0.1);
-  border: 1px solid rgba(217, 119, 6, 0.3);
+  background: rgba(217, 119, 6, 0.08);
+  border: 1px solid rgba(217, 119, 6, 0.22);
 }
 .pillCrit {
   color: #b91c1c;
   background: rgba(220, 38, 38, 0.08);
-  border: 1px solid rgba(220, 38, 38, 0.3);
+  border: 1px solid rgba(220, 38, 38, 0.22);
 }
 .pillDot {
   width: 7px; height: 7px; border-radius: 50%; background: var(--green);
@@ -87,9 +83,9 @@
 
 .boardFoot {
   margin-top: auto;
-  padding: 14px 20px;
+  padding: 13px 18px;
   border-top: 1px solid var(--border);
-  background: var(--bg-2);
+  background: #fafafa;
   display: flex; align-items: center; justify-content: space-between;
   font-size: 12px; color: var(--muted);
   gap: 10px 14px; flex-wrap: wrap;
@@ -106,8 +102,8 @@
 }
 .gpu {
   padding: 12px 14px;
-  border-radius: 10px;
-  background: var(--bg-2);
+  border-radius: 6px;
+  background: #fafafa;
   border: 1px solid var(--border);
 }
 .gpuTop {
@@ -145,17 +141,17 @@
   letter-spacing: 0.04em;
 }
 .gpuBar {
-  height: 7px; border-radius: 999px;
-  background: rgba(126, 34, 206, 0.1);
+  height: 6px; border-radius: 999px;
+  background: rgba(0, 0, 0, 0.06);
   overflow: hidden;
 }
 .gpuBarFill {
   display: block; height: 100%; border-radius: 999px;
   transition: width 0.4s ease;
 }
-.gpuBarFill.ok { background: linear-gradient(90deg, var(--accent), var(--accent-2)); }
-.gpuBarFill.warn { background: linear-gradient(90deg, var(--amber), #f97316); }
-.gpuBarFill.crit { background: linear-gradient(90deg, var(--red), #ef4444); }
+.gpuBarFill.ok { background: #0a0a0a; }
+.gpuBarFill.warn { background: var(--amber); }
+.gpuBarFill.crit { background: var(--red); }
 .gpuBarVal {
   font-size: 11px; color: var(--text-dim);
   font-family: 'JetBrains Mono', monospace; text-align: right;
@@ -204,8 +200,9 @@
 }
 .chartSvg {
   width: 100%; height: 110px; display: block;
-  background: linear-gradient(180deg, rgba(126, 34, 206, 0.04), transparent);
-  border-radius: 8px;
+  background: #fafafa;
+  border: 1px solid var(--border);
+  border-radius: 6px;
 }
 
 /* ---- Inference board ---- */
@@ -216,84 +213,78 @@
 }
 .infCell {
   padding: 12px 14px;
-  border-radius: 9px;
-  background: var(--bg-2);
+  border-radius: 6px;
+  background: #fafafa;
   border: 1px solid var(--border);
-  /* Keep all four KPI cells visually equal regardless of whether they
-     have a sub-hint line, so the 2x2 grid never looks lopsided. */
   display: flex; flex-direction: column; justify-content: center;
   min-height: 78px;
 }
-/* A bit more breathing between the label and the big number inside KPI
-   cells, matching the .trainGrid rhythm. */
 .infCell .statLbl { margin-bottom: 6px; }
 
 .histogram {
   display: flex; align-items: flex-end; gap: 5px;
   height: 110px;
   padding: 8px 10px;
-  background: linear-gradient(180deg, rgba(126, 34, 206, 0.04), transparent);
-  border-radius: 8px;
+  background: #fafafa;
+  border: 1px solid var(--border);
+  border-radius: 6px;
 }
 .histBar {
   flex: 1; min-width: 0;
-  background: linear-gradient(180deg, var(--accent), var(--accent-2));
-  border-radius: 3px 3px 0 0;
-  opacity: 0.85;
+  background: #0a0a0a;
+  border-radius: 2px 2px 0 0;
+  opacity: 0.88;
   transition: height 0.4s ease;
 }
 .histBar[data-bad="true"] {
-  background: linear-gradient(180deg, var(--amber), #f97316);
+  background: var(--amber);
 }
 
 /* ---- Failures catalog ---- */
-.failures { margin-top: 64px; }
+.failures { margin-top: 56px; }
 .failuresHead {
-  text-align: center; max-width: 720px; margin: 0 auto 36px;
+  text-align: center; max-width: 720px; margin: 0 auto 32px;
 }
 .failuresHead h3 {
-  font-size: clamp(24px, 2.8vw, 32px);
+  font-size: clamp(22px, 2.6vw, 30px);
   font-weight: 700; letter-spacing: -0.02em; line-height: 1.15;
   margin-top: 14px; margin-bottom: 12px;
-  background: var(--grad-text);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--text);
 }
-.failuresHead p { color: var(--muted); font-size: 15px; line-height: 1.55; }
+.failuresHead p { color: var(--muted); font-size: 15px; line-height: 1.6; }
 
 .failGrid {
   display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px;
 }
 .failCard {
-  display: flex; gap: 12px;
   padding: 18px; border-radius: var(--radius);
   background: var(--surface);
   border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.18);
-  transition: all 0.2s;
-  align-items: flex-start;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   min-width: 0;
 }
-.failCard > div { min-width: 0; }
 .failCard:hover {
-  border-color: rgba(126, 34, 206, 0.4);
+  border-color: var(--border-strong);
   transform: translateY(-2px);
-  box-shadow: 0 14px 32px -16px rgba(126, 34, 206, 0.28);
+  box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.18);
+}
+.failHead {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 6px;
 }
 .failIco {
-  width: 36px; height: 36px; border-radius: 9px;
-  background: linear-gradient(135deg, rgba(126, 34, 206, 0.12), rgba(79, 70, 229, 0.1));
-  border: 1px solid rgba(126, 34, 206, 0.22);
-  color: var(--accent);
   display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-mute);
   flex-shrink: 0;
+  width: 16px; height: 16px;
 }
 .failTitle {
-  font-size: 13.5px; font-weight: 600; color: var(--text);
-  letter-spacing: -0.01em; margin-bottom: 3px;
+  font-size: 14px; font-weight: 600; color: var(--text);
+  letter-spacing: -0.005em; line-height: 1.3;
 }
 .failDesc {
-  font-size: 12px; color: var(--muted); line-height: 1.45;
+  font-size: 12.5px; color: var(--muted); line-height: 1.55;
 }
 
 @media (max-width: 980px) {

--- a/src/components/sections/MLOps.tsx
+++ b/src/components/sections/MLOps.tsx
@@ -56,8 +56,8 @@ export default function MLOps() {
           <div className={styles.board}>
             <div className={styles.boardHead}>
               <div className={styles.boardTitleWrap}>
-                <span className={styles.boardIco} style={{ background: 'rgba(168,85,247,0.18)', color: '#d8b4fe' }}>
-                  <Icon name="cpu" size={16} strokeWidth={2.2} />
+                <span className={styles.boardIco}>
+                  <Icon name="cpu" size={16} strokeWidth={1.6} />
                 </span>
                 <div>
                   <div className={styles.boardTitle}>GPU fleet</div>
@@ -115,8 +115,8 @@ export default function MLOps() {
           <div className={styles.board}>
             <div className={styles.boardHead}>
               <div className={styles.boardTitleWrap}>
-                <span className={styles.boardIco} style={{ background: 'rgba(99,102,241,0.18)', color: '#a5b4fc' }}>
-                  <Icon name="trending" size={16} strokeWidth={2.2} />
+                <span className={styles.boardIco}>
+                  <Icon name="trending" size={16} strokeWidth={1.6} />
                 </span>
                 <div>
                   <div className={styles.boardTitle}>Training run · llama-ft-7b</div>
@@ -188,8 +188,8 @@ export default function MLOps() {
           <div className={styles.board}>
             <div className={styles.boardHead}>
               <div className={styles.boardTitleWrap}>
-                <span className={styles.boardIco} style={{ background: 'rgba(52,211,153,0.16)', color: 'var(--green)' }}>
-                  <Icon name="gauge" size={16} strokeWidth={2.2} />
+                <span className={styles.boardIco}>
+                  <Icon name="gauge" size={16} strokeWidth={1.6} />
                 </span>
                 <div>
                   <div className={styles.boardTitle}>Inference · vLLM serving</div>
@@ -256,13 +256,13 @@ export default function MLOps() {
           <div className={styles.failGrid}>
             {failureModes.map((f) => (
               <div key={f.label} className={styles.failCard}>
-                <span className={styles.failIco}>
-                  <Icon name={f.ico as any} size={18} strokeWidth={2.2} />
-                </span>
-                <div>
+                <div className={styles.failHead}>
+                  <span className={styles.failIco}>
+                    <Icon name={f.ico as any} size={16} strokeWidth={1.6} />
+                  </span>
                   <div className={styles.failTitle}>{f.label}</div>
-                  <div className={styles.failDesc}>{f.desc}</div>
                 </div>
+                <div className={styles.failDesc}>{f.desc}</div>
               </div>
             ))}
           </div>

--- a/src/components/sections/Outcomes.module.css
+++ b/src/components/sections/Outcomes.module.css
@@ -1,21 +1,21 @@
 .row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .quote {
-  padding: 28px; border-radius: var(--radius-lg);
-  background: linear-gradient(180deg, rgba(126, 34, 206, 0.05) 0%, #ffffff 100%);
+  padding: 28px; border-radius: var(--radius);
+  background: var(--surface);
   border: 1px solid var(--border);
-  box-shadow: 0 8px 24px -16px rgba(76, 29, 149, 0.2);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
 }
 .qmark {
-  font-family: Georgia, serif; font-size: 40px; line-height: 0.5;
-  color: var(--accent); display: block; height: 20px;
+  font-family: Georgia, serif; font-size: 36px; line-height: 0.5;
+  color: var(--accent); display: block; height: 18px;
 }
-.quote p { font-size: 15px; color: var(--text); line-height: 1.55; margin: 12px 0 18px; }
+.quote p { font-size: 15px; color: var(--text); line-height: 1.6; margin: 12px 0 18px; }
 .who { display: flex; align-items: center; gap: 12px; }
 .av {
   width: 36px; height: 36px; border-radius: 50%;
-  background: var(--grad-primary);
+  background: #18181b;
   display: inline-flex; align-items: center; justify-content: center;
-  color: #fff; font-weight: 700; font-size: 14px;
+  color: #fff; font-weight: 700; font-size: 13px;
 }
 .name { font-size: 13px; font-weight: 600; color: var(--text); }
 .role { font-size: 12px; color: var(--muted); }

--- a/src/components/sections/Pains.module.css
+++ b/src/components/sections/Pains.module.css
@@ -2,25 +2,32 @@
   display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
 }
 .pain {
-  padding: 28px; border-radius: var(--radius);
+  padding: 24px; border-radius: var(--radius);
   background: var(--surface);
   border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.18);
-  transition: all 0.25s;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 .pain:hover {
-  border-color: rgba(220, 38, 38, 0.4);
-  transform: translateY(-3px);
-  box-shadow: 0 14px 32px -16px rgba(220, 38, 38, 0.25);
-  background: #fff;
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.18);
 }
-.icoBox {
-  width: 42px; height: 42px; border-radius: 10px;
-  background: rgba(248, 113, 113, 0.1); color: var(--red);
+.head {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 8px;
+}
+.ico {
   display: inline-flex; align-items: center; justify-content: center;
-  margin-bottom: 16px;
+  color: var(--text-mute);
+  flex-shrink: 0;
+  width: 16px; height: 16px;
 }
-.pain h4 { font-size: 16px; font-weight: 600; margin-bottom: 8px; }
-.pain p { font-size: 14px; color: var(--muted); line-height: 1.55; }
+.pain h4 {
+  font-size: 15px; font-weight: 600; color: var(--text);
+  letter-spacing: -0.005em; line-height: 1.3;
+  margin: 0;
+}
+.pain p { font-size: 14px; color: var(--muted); line-height: 1.6; margin: 0; }
 
 @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }

--- a/src/components/sections/Pains.tsx
+++ b/src/components/sections/Pains.tsx
@@ -3,47 +3,47 @@ import styles from './Pains.module.css';
 
 const pains: { ico: React.ReactNode; title: string; body: string }[] = [
   {
-    ico: <Icon name="eye" size={22} />,
+    ico: <Icon name="eye" size={16} strokeWidth={1.6} />,
     title: 'Observability as an afterthought',
     body: 'Endpoints and services go live before anyone can really see them. Logs and metrics sit in different consoles.',
   },
   {
-    ico: <Icon name="bolt" size={22} />,
+    ico: <Icon name="bolt" size={16} strokeWidth={1.6} />,
     title: 'Alert noise & paging fatigue',
     body: 'Alertmanager, Datadog, custom webhooks, all firing into one Slack channel with no correlation or routing.',
   },
   {
-    ico: <Icon name="activity" size={22} />,
+    ico: <Icon name="activity" size={16} strokeWidth={1.6} />,
     title: 'Kubernetes complexity outpaces the team',
     body: 'CrashLoopBackOff, OOMKilled, scheduling failures. Every incident becomes a kubectl scavenger hunt.',
   },
   {
-    ico: <Icon name="clock" size={22} />,
+    ico: <Icon name="clock" size={16} strokeWidth={1.6} />,
     title: 'On-call burns out the best engineers',
     body: 'No structured rotations, no escalation paths, no audit trail. Your senior SRE is the human pager.',
   },
   {
-    ico: <Icon name="dollar" size={22} />,
+    ico: <Icon name="dollar" size={16} strokeWidth={1.6} />,
     title: 'Cloud bills nobody can explain',
     body: 'Over-provisioned requests, idle EC2, forgotten RDS, while finance asks why spend doubled this quarter.',
   },
   {
-    ico: <Icon name="message" size={22} />,
+    ico: <Icon name="message" size={16} strokeWidth={1.6} />,
     title: 'Tribal knowledge in shell history',
     body: "Recovery steps live in someone's terminal scrollback. New engineers re-learn every fire drill.",
   },
   {
-    ico: <Icon name="cpu" size={22} />,
+    ico: <Icon name="cpu" size={16} strokeWidth={1.6} />,
     title: 'GPU fleets are flying blind',
     body: 'CUDA OOM, NCCL timeouts, MIG slices unaccounted for. Half the H100s are idle while the other half throttle, and nobody can prove it.',
   },
   {
-    ico: <Icon name="workflow" size={22} />,
+    ico: <Icon name="workflow" size={16} strokeWidth={1.6} />,
     title: 'ML pipelines stall silently',
     body: 'A Kubeflow DAG hangs at step 7. A vLLM replica drifts on p99. Nobody pages until the data scientist files a ticket.',
   },
   {
-    ico: <Icon name="trending" size={22} />,
+    ico: <Icon name="trending" size={16} strokeWidth={1.6} />,
     title: "Training runs you can't trust",
     body: 'Loss diverges, gradients NaN, dataloader stalls. You burn $14k of GPU hours before someone checks Weights & Biases.',
   },
@@ -65,8 +65,10 @@ export default function Pains() {
         <div className={`${styles.grid} reveal`}>
           {pains.map((p) => (
             <div key={p.title} className={styles.pain}>
-              <div className={styles.icoBox}>{p.ico}</div>
-              <h4>{p.title}</h4>
+              <div className={styles.head}>
+                <span className={styles.ico}>{p.ico}</span>
+                <h4>{p.title}</h4>
+              </div>
               <p>{p.body}</p>
             </div>
           ))}

--- a/src/components/sections/Runbooks.module.css
+++ b/src/components/sections/Runbooks.module.css
@@ -2,7 +2,7 @@
   display: grid; grid-template-columns: 1fr 280px; gap: 20px;
 }
 .canvas {
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   background: #ffffff;
   border: 1px solid var(--border);
   overflow: hidden;
@@ -12,22 +12,22 @@
 .bar {
   display: flex; align-items: center; justify-content: space-between;
   padding: 12px 16px;
-  background: var(--bg-2);
+  background: #fafafa;
   border-bottom: 1px solid var(--border);
   gap: 12px;
 }
 .tabs { display: flex; gap: 6px; flex-wrap: wrap; min-width: 0; }
 .tab {
   display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 12px; border-radius: 8px;
+  padding: 6px 12px; border-radius: 4px;
   font-size: 12px; color: var(--muted);
   background: #ffffff;
   border: 1px solid var(--border);
   white-space: nowrap;
 }
 .tabActive {
-  color: var(--text); background: rgba(126, 34, 206, 0.1);
-  border-color: rgba(126, 34, 206, 0.35);
+  color: var(--text); background: var(--surface-strong);
+  border-color: var(--border-strong);
 }
 
 .barActions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
@@ -36,8 +36,8 @@
   padding: 4px 10px; border-radius: 999px;
   font-size: 11px; font-weight: 700; letter-spacing: 0.06em;
   color: #047857;
-  background: rgba(5, 150, 105, 0.1);
-  border: 1px solid rgba(5, 150, 105, 0.3);
+  background: rgba(5, 150, 105, 0.08);
+  border: 1px solid rgba(5, 150, 105, 0.22);
 }
 .activeDot {
   width: 7px; height: 7px; border-radius: 50%; background: var(--green);
@@ -45,16 +45,16 @@
 }
 .playBtn {
   display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 12px; border-radius: 8px;
+  padding: 6px 12px; border-radius: 4px;
   font-size: 12px; font-weight: 600;
-  background: var(--grad-primary); color: #fff;
-  box-shadow: 0 4px 16px -4px rgba(126, 34, 206, 0.5);
+  background: #0a0a0a; color: #fff;
 }
+.playBtn:hover { background: #18181b; }
 
 .stage {
   position: relative;
   height: 480px;
-  background-color: #faf5ff;
+  background-color: #fafafa;
   overflow: hidden;
 }
 .edges {
@@ -65,10 +65,10 @@
 .node {
   position: absolute;
   width: 180px; padding: 10px 12px;
-  border-radius: 11px;
+  border-radius: 8px;
   background: #ffffff;
   border: 1px solid var(--border);
-  box-shadow: 0 8px 24px -10px rgba(76, 29, 149, 0.2);
+  box-shadow: 0 6px 18px -10px rgba(0, 0, 0, 0.14);
   transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
   overflow: hidden;
   opacity: 0;
@@ -80,16 +80,16 @@
 }
 .node:hover {
   transform: translateY(-2px);
-  border-color: rgba(126, 34, 206, 0.5);
-  box-shadow: 0 14px 36px -10px rgba(126, 34, 206, 0.28);
+  border-color: #18181b;
+  box-shadow: 0 12px 28px -12px rgba(0, 0, 0, 0.22);
 }
-.trigger { border-color: rgba(220, 38, 38, 0.3); }
-.condition { border-color: rgba(217, 119, 6, 0.3); }
-.approval { border-color: rgba(126, 34, 206, 0.4); }
-.remediate { border-color: rgba(126, 34, 206, 0.4); }
-.summary { border-color: rgba(5, 150, 105, 0.3); }
+.trigger { border-color: rgba(220, 38, 38, 0.30); }
+.condition { border-color: rgba(217, 119, 6, 0.30); }
+.approval { border-color: rgba(109, 40, 217, 0.40); }
+.remediate { border-color: rgba(109, 40, 217, 0.40); }
+.summary { border-color: rgba(5, 150, 105, 0.30); }
 
-/* Subtle diagonal shine that sweeps across nodes occasionally */
+/* Subtle shine — toned down */
 .nodeShine {
   position: absolute;
   top: 0; left: -60%;
@@ -97,7 +97,7 @@
   background: linear-gradient(
     100deg,
     transparent 20%,
-    rgba(168, 85, 247, 0.08) 50%,
+    rgba(0, 0, 0, 0.06) 50%,
     transparent 80%
   );
   transform: skewX(-18deg);
@@ -110,7 +110,7 @@
 @keyframes nodeShine {
   0%, 60%, 100% { left: -60%; opacity: 0; }
   70% { opacity: 1; }
-  90% { left: 120%; opacity: 0.4; }
+  90% { left: 120%; opacity: 0.35; }
 }
 
 .nodeH {
@@ -118,7 +118,7 @@
   margin-bottom: 6px;
 }
 .nodeIco {
-  width: 22px; height: 22px; border-radius: 6px;
+  width: 22px; height: 22px; border-radius: 4px;
   display: inline-flex; align-items: center; justify-content: center;
   flex-shrink: 0;
 }
@@ -130,7 +130,6 @@
 .nodeBrand {
   width: 14px; height: 14px; flex-shrink: 0;
   border-radius: 3px;
-  filter: drop-shadow(0 1px 2px rgba(20, 10, 40, 0.12));
 }
 .nodeTitle {
   font-size: 13px; font-weight: 600; color: var(--text);
@@ -144,7 +143,7 @@
 
 .palette {
   padding: 16px;
-  background: var(--bg-2);
+  background: #fafafa;
   border-top: 1px solid var(--border);
   display: grid;
   gap: 14px;
@@ -165,13 +164,13 @@
   border: 1px solid var(--border);
   color: var(--text-dim);
   font-family: 'JetBrains Mono', monospace;
-  transition: all 0.2s;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
   cursor: default;
 }
 .chip:hover {
-  background: rgba(126, 34, 206, 0.08);
-  border-color: rgba(126, 34, 206, 0.3);
-  color: var(--accent);
+  background: var(--surface-strong);
+  border-color: #18181b;
+  color: var(--text);
   transform: translateY(-1px);
 }
 .chipBrand {
@@ -183,15 +182,14 @@
 .chipLogo {
   width: 14px; height: 14px; flex-shrink: 0;
   display: block;
-  filter: drop-shadow(0 1px 1px rgba(20, 10, 40, 0.10));
 }
-.chipSoon { opacity: 0.6; }
+.chipSoon { opacity: 0.55; }
 .chipSoonTag {
   display: inline-block;
   font-size: 9px; font-weight: 700; letter-spacing: 0.06em;
   text-transform: uppercase;
   padding: 1px 6px; border-radius: 999px;
-  background: rgba(126, 34, 206, 0.12);
+  background: var(--accent-soft);
   color: var(--accent);
   margin-left: 2px;
   font-family: ui-sans-serif, system-ui, sans-serif;
@@ -201,19 +199,22 @@
 .railCard {
   padding: 18px 20px; border-radius: var(--radius);
   background: var(--surface); border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.16);
-  transition: all 0.25s;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
-.railCard:hover { border-color: rgba(126, 34, 206, 0.4); transform: translateX(-3px); }
+.railCard:hover {
+  border-color: var(--border-strong);
+  transform: translateX(-2px);
+  box-shadow: 0 10px 22px -16px rgba(0, 0, 0, 0.18);
+}
 .railNum {
-  font-size: 24px; font-weight: 800; letter-spacing: -0.03em;
-  background: var(--grad-primary);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  font-size: 22px; font-weight: 700; letter-spacing: -0.03em;
+  color: var(--text);
   line-height: 1;
+  font-family: 'JetBrains Mono', monospace;
 }
 .railH { font-size: 14px; font-weight: 600; color: var(--text); margin: 6px 0 4px; }
-.railCard p { font-size: 12px; color: var(--muted); line-height: 1.5; }
+.railCard p { font-size: 12px; color: var(--muted); line-height: 1.55; }
 
 @media (max-width: 980px) {
   .wrap { grid-template-columns: 1fr; }

--- a/src/components/sections/Services.module.css
+++ b/src/components/sections/Services.module.css
@@ -1,5 +1,5 @@
 .section {
-  background: linear-gradient(180deg, transparent 0%, rgba(126, 34, 206, 0.04) 50%, transparent 100%);
+  background: transparent;
 }
 
 .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
@@ -8,14 +8,14 @@
   padding: 20px; border-radius: var(--radius);
   background: var(--surface);
   border: 1px solid var(--border);
-  box-shadow: 0 4px 18px -10px rgba(76, 29, 149, 0.16);
-  transition: all 0.25s ease;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   position: relative; overflow: hidden;
 }
 .card:hover {
-  border-color: rgba(126, 34, 206, 0.4);
-  transform: translateY(-3px);
-  box-shadow: 0 16px 40px -16px rgba(126, 34, 206, 0.32);
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px -18px rgba(0, 0, 0, 0.20);
 }
 
 .head {
@@ -23,12 +23,11 @@
   margin-bottom: 14px;
 }
 .logoChip {
-  width: 38px; height: 38px; border-radius: 9px;
+  width: 36px; height: 36px; border-radius: 6px;
   background: #ffffff;
   border: 1px solid var(--border);
   display: inline-flex; align-items: center; justify-content: center;
   flex-shrink: 0;
-  box-shadow: 0 4px 12px -8px rgba(76, 29, 149, 0.25);
 }
 .logoImg {
   width: 22px; height: 22px;
@@ -36,11 +35,11 @@
   display: block;
 }
 .moreIco {
-  width: 36px; height: 36px; border-radius: 8px;
-  background: rgba(126, 34, 206, 0.1);
+  width: 36px; height: 36px; border-radius: 6px;
+  background: var(--accent-soft);
   color: var(--accent);
   display: inline-flex; align-items: center; justify-content: center;
-  border: 1px solid rgba(126, 34, 206, 0.28);
+  border: 1px solid rgba(109, 40, 217, 0.20);
 }
 .name {
   font-size: 15px; font-weight: 600; color: var(--text);
@@ -55,28 +54,28 @@
   border: 1px solid var(--border);
   color: var(--text-dim);
   font-family: 'JetBrains Mono', monospace;
-  transition: all 0.2s;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 .card:hover .mode {
-  background: rgba(126, 34, 206, 0.08);
-  border-color: rgba(126, 34, 206, 0.25);
-  color: var(--accent);
+  background: var(--surface-strong);
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .more {
-  background: linear-gradient(180deg, rgba(126, 34, 206, 0.05) 0%, #ffffff 100%);
+  background: #fafafa;
   border-style: dashed;
-  border-color: rgba(126, 34, 206, 0.3);
+  border-color: var(--border-strong);
 }
 
 .foot {
   margin-top: 32px;
   display: flex; justify-content: space-between; align-items: center;
   gap: 20px; padding: 22px 24px; border-radius: var(--radius);
-  background: linear-gradient(135deg, rgba(126, 34, 206, 0.06), rgba(79, 70, 229, 0.04));
-  border: 1px solid rgba(126, 34, 206, 0.18);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
 }
-.footText { font-size: 14px; color: var(--text-dim); line-height: 1.55; }
+.footText { font-size: 14px; color: var(--text-dim); line-height: 1.6; }
 .footText b { color: var(--text); font-weight: 600; }
 
 @media (max-width: 980px) {

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,7 @@
   }
   
   body {
-    @apply bg-white text-purple-800 font-sans;
+    @apply bg-white text-zinc-900 font-sans;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
   
@@ -208,17 +208,17 @@
   }
   
   thead {
-    background: #faf5ff;
+    background: #fafafa;
   }
-  
+
   th {
     padding: 1rem;
     text-align: left;
     font-weight: 600;
-    color: #581c87;
-    border-right: 1px solid #e9d5ff;
-    border-bottom: 2px solid #c084fc;
-    background: #faf5ff;
+    color: #18181b;
+    border-right: 1px solid #e4e4e7;
+    border-bottom: 2px solid #d4d4d8;
+    background: #fafafa;
     font-size: 0.9375rem;
   }
   
@@ -257,7 +257,7 @@
   }
   
   tbody tr:hover {
-    background: #f3e8ff;
+    background: #f4f4f5;
   }
   
   @media (max-width: 768px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,28 +1,48 @@
 /* ---------- Reset & tokens ---------- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 :root {
+  /* Surfaces — white / near-white */
   --bg: #ffffff;
-  --bg-2: #faf5ff;
+  --bg-2: #fafafa;
   --surface: #ffffff;
-  --surface-strong: #faf5ff;
-  --border: rgba(126, 34, 206, 0.14);
-  --border-strong: rgba(126, 34, 206, 0.28);
-  --text: #3b0764;          /* purple-950 */
-  --text-dim: #6b21a8;      /* purple-800 */
-  --text-mute: #7e22ce;     /* purple-700 */
-  --muted: #6b7280;         /* slate-500 for secondary copy */
-  --accent: #7e22ce;        /* purple-700 */
-  --accent-2: #4f46e5;      /* indigo-600 */
-  --accent-3: #c026d3;      /* fuchsia-600 */
+  --surface-strong: #f4f4f5;     /* zinc-100 */
+
+  /* Borders */
+  --border: rgba(0, 0, 0, 0.08);
+  --border-strong: rgba(0, 0, 0, 0.14);
+
+  /* Text — black-dominant on white */
+  --text: #0a0a0a;                /* near-black */
+  --text-dim: #27272a;            /* zinc-800 */
+  --text-mute: #52525b;           /* zinc-600 */
+  --muted: #71717a;               /* zinc-500 — for secondary copy */
+
+  /* Accents — restrained purple as the only color */
+  --accent: #6d28d9;              /* violet-700 — used for sec-tag, focus, badges */
+  --accent-soft: #ede9fe;         /* violet-100 — soft fills */
+  --accent-deep: #4c1d95;         /* violet-900 — hover/active */
+  --accent-2: #18181b;            /* zinc-900 — replaces secondary purple */
+  --accent-3: #a855f7;            /* violet-500 — used sparingly for highlights */
+
+  /* Status */
   --green: #059669;
   --amber: #d97706;
   --red: #dc2626;
-  --radius: 16px;
-  --radius-lg: 24px;
-  --shadow-glow: 0 20px 60px -20px rgba(126, 34, 206, 0.35);
-  --shadow-card: 0 12px 40px -12px rgba(76, 29, 149, 0.18);
-  --grad-primary: linear-gradient(135deg, #6b21a8 0%, #4f46e5 50%, #c026d3 100%);
-  --grad-text: linear-gradient(135deg, #3b0764 0%, #4f46e5 50%, #c026d3 100%);
+
+  /* Radii — tight */
+  --radius: 8px;
+  --radius-lg: 10px;
+  --radius-sm: 6px;
+  --radius-pill: 999px;
+
+  /* Shadows — softer, neutral */
+  --shadow-glow: 0 18px 50px -22px rgba(0, 0, 0, 0.18);
+  --shadow-card: 0 8px 24px -14px rgba(0, 0, 0, 0.10);
+
+  /* Gradients — black-dominant, purple used as restrained accent */
+  --grad-primary: linear-gradient(135deg, #18181b 0%, #0a0a0a 100%);
+  --grad-text: linear-gradient(135deg, #0a0a0a 0%, #27272a 100%);
+  --grad-accent: linear-gradient(135deg, #6d28d9 0%, #4c1d95 100%);
 }
 html {
   -webkit-text-size-adjust: 100%;
@@ -43,46 +63,45 @@ body.alertmend-dark a { color: inherit; text-decoration: none; }
 /* Inherit the body font + show a pointer for buttons. We deliberately do NOT
    reset background / color / border globally, because legacy Tailwind pages
    (Pricing, About, Blog, etc.) style their buttons with utility classes
-   (`bg-*`, `text-*`, `border`) that would otherwise be wiped out. The new
-   homepage's `.btn` family sets its own background / color / border
-   explicitly, so it does not need a global reset. */
+   (`bg-*`, `text-*`, `border`) that would otherwise be wiped out. */
 body.alertmend-dark button { font-family: inherit; cursor: pointer; }
+
+/* Selection color stays subtly on-brand */
+::selection { background: var(--accent); color: #ffffff; }
 
 /* ---------- Layout ---------- */
 .container { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
-section { padding: 72px 0; position: relative; }
-section.tight { padding: 48px 0; }
-/* First section after the nav gets a tighter top so the page doesn't start with a big empty band */
+section { padding: 80px 0; position: relative; }
+section.tight { padding: 56px 0; }
+/* First section after the nav. Give the H1 enough breathing room from the
+   sticky nav so the page doesn't feel cramped at the top of the viewport. */
 main > section:first-of-type,
-.page-top { padding-top: 36px; }
+.page-top { padding-top: 80px; }
 
 /* ---------- Buttons ----------
-   NOTE on specificity: `body.alertmend-dark a { color: inherit }` (0,1,1) is
-   higher specificity than a plain `.btn-primary` (0,1,0). Any `.btn-*` that
-   renders as an <a> / <Link> would inherit the dark page text and read
-   as near-black on the purple gradient. We scope button color/background
-   rules under `body.alertmend-dark` so they always win on this site. */
+   Black primary button is the dominant CTA language; purple is reserved
+   for accent text / dots / focus rings. Specificity is scoped under
+   `body.alertmend-dark` so legacy Tailwind utility-class buttons on
+   other pages are unaffected. */
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 11px 20px; border-radius: 10px;
+  padding: 11px 20px; border-radius: 6px;
   font-weight: 600; font-size: 14px; letter-spacing: -0.005em;
-  transition: all 0.2s ease; white-space: nowrap;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease,
+              box-shadow 0.18s ease, transform 0.06s ease;
+  white-space: nowrap;
   border: 1px solid transparent;
 }
 body.alertmend-dark .btn-primary,
 body.alertmend-dark a.btn-primary,
 body.alertmend-dark a.btn-primary:visited {
-  background: var(--grad-primary);
+  background: #0a0a0a;
   color: #ffffff;
   -webkit-text-fill-color: #ffffff;
-  background-clip: border-box;
-  -webkit-background-clip: border-box;
-  box-shadow:
-    0 10px 28px -10px rgba(168, 85, 247, 0.55),
-    0 4px 14px -6px rgba(192, 38, 211, 0.32),
-    inset 0 1px 0 rgba(255, 255, 255, 0.28),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.12);
-  text-shadow: 0 1px 1px rgba(59, 7, 100, 0.2);
+  border-color: #0a0a0a;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08) inset,
+              0 1px 2px rgba(0, 0, 0, 0.18),
+              0 6px 18px -10px rgba(0, 0, 0, 0.35);
 }
 body.alertmend-dark .btn-primary *,
 body.alertmend-dark .btn-primary svg,
@@ -92,96 +111,87 @@ body.alertmend-dark .btn-primary svg * {
   stroke: currentColor;
 }
 body.alertmend-dark .btn-primary:hover {
-  box-shadow:
-    0 12px 32px -10px rgba(168, 85, 247, 0.6),
-    0 4px 14px -6px rgba(192, 38, 211, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.3),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.12);
-  filter: brightness(1.04);
+  background: #18181b;
+  border-color: #18181b;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.10) inset,
+              0 2px 4px rgba(0, 0, 0, 0.20),
+              0 8px 22px -10px rgba(0, 0, 0, 0.40);
 }
+body.alertmend-dark .btn-primary:active { transform: translateY(0.5px); }
+
 body.alertmend-dark .btn-ghost,
 body.alertmend-dark a.btn-ghost,
 body.alertmend-dark a.btn-ghost:visited {
   background: #ffffff;
-  color: var(--text-dim);
+  color: var(--text);
   -webkit-text-fill-color: currentColor;
   border-color: var(--border-strong);
-  box-shadow: 0 1px 2px rgba(76, 29, 149, 0.06);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
 }
 body.alertmend-dark .btn-ghost:hover {
   background: var(--bg-2);
-  border-color: rgba(126, 34, 206, 0.45);
+  border-color: #18181b;
   color: var(--text);
 }
-.btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 12px; }
-.btn .arrow { transition: transform 0.2s; }
-.btn:hover .arrow { transform: translateX(3px); }
+.btn-lg { padding: 13px 24px; font-size: 15px; border-radius: 6px; }
+.btn .arrow { transition: transform 0.18s ease; }
+.btn:hover .arrow { transform: translateX(2px); }
+
+/* Focus ring uses the accent purple — visible but not loud */
+body.alertmend-dark .btn:focus-visible,
+body.alertmend-dark a.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px var(--accent);
+}
 
 /* ---------- Section heading ---------- */
 .sec-head { text-align: center; max-width: 720px; margin: 0 auto 56px; }
 .sec-tag {
   display: inline-flex; align-items: center; gap: 10px;
-  font-size: 12px; font-weight: 700;
-  letter-spacing: 0.14em; text-transform: uppercase;
-  color: var(--accent);
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--text-mute);
   margin-bottom: 14px;
   padding: 0; border: 0; background: none;
 }
 .sec-tag::before {
   content: '';
-  width: 7px; height: 7px; border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), var(--accent-3));
-  box-shadow:
-    0 0 0 4px rgba(126, 34, 206, 0.10),
-    0 0 12px rgba(126, 34, 206, 0.55);
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(109, 40, 217, 0.10);
   flex-shrink: 0;
-  animation: secTagPulse 2.4s ease-in-out infinite;
-}
-@keyframes secTagPulse {
-  0%, 100% {
-    box-shadow:
-      0 0 0 4px rgba(126, 34, 206, 0.10),
-      0 0 12px rgba(126, 34, 206, 0.45);
-  }
-  50% {
-    box-shadow:
-      0 0 0 5px rgba(126, 34, 206, 0.16),
-      0 0 18px rgba(126, 34, 206, 0.70);
-  }
 }
 .sec-head h2 {
-  font-size: clamp(32px, 4vw, 48px); line-height: 1.1; letter-spacing: -0.025em;
+  font-size: clamp(30px, 3.8vw, 44px); line-height: 1.1; letter-spacing: -0.025em;
   font-weight: 700;
-  background: var(--grad-text);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--text);
 }
 .sec-head p {
-  margin-top: 18px; font-size: 17px; color: var(--muted); line-height: 1.55;
+  margin-top: 16px; font-size: 16px; color: var(--muted); line-height: 1.6;
 }
 
+/* Inline accent for highlighting a word in headlines.
+   Use sparingly — this is the one place purple is loud. */
 .hero-h-accent {
-  background: var(--grad-primary);
-  -webkit-background-clip: text; background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--accent);
 }
 
 /* ---------- Reveal animations ---------- */
 .reveal {
-  opacity: 0; transform: translateY(20px);
-  transition: opacity 0.8s ease, transform 0.8s ease;
+  opacity: 0; transform: translateY(16px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
 }
 .reveal.visible { opacity: 1; transform: translateY(0); }
 
 /* ---------- Pulse keyframes (used by multiple components) ---------- */
 @keyframes pulse {
-  0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.7); }
-  70% { box-shadow: 0 0 0 10px rgba(52, 211, 153, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0.5); }
+  70% { box-shadow: 0 0 0 10px rgba(5, 150, 105, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0); }
 }
 @keyframes pulseDot {
   0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.5; transform: scale(1.4); }
+  50% { opacity: 0.55; transform: scale(1.35); }
 }
 @keyframes float {
   0%, 100% { transform: translate(0, 0); }


### PR DESCRIPTION
Closes #18.

## Summary
- Retune `src/styles/global.css` design tokens to a near-black + zinc palette with a single restrained violet accent; radii tightened (16/24px → 6/8/10px); shadows neutralized.
- Hero, Pains, Features, MLOps, Services, Runbooks, HowItWorks, AISpotlight, Outcomes, Integrations, FinalCTA: drop hardcoded purple tints, swap stacked icon plates for inline thin icons (16px stroke-1.6), restructure section heads.
- Nav rebuilt to industry-standard 5 primary links + quiet right cluster; "Playground" surfaced as a `● LIVE Playground` pill that signals the running product without competing with the primary `Book a demo` CTA.
- FinalCTA: rebuilt with deep purple-tinted background, two radial corner glows, dotted texture mask, and a high-specificity white primary button that beats the global black-button cascade.
- AmbientBackground: CSS-only ambient grid (no network) + three corner radial purple washes, masked so the grid fades past the fold.
- Mobile (390px) verified: H1 wraps, navbar collapses to brand + hamburger, drawer presents stacked nav + CTAs, FinalCTA scales padding down.
- Add `CLAUDE.md` documenting the build pipeline and the three rendering paths (marketing prerender, blog HTML generator, runtime React markdown).

## Test plan
- [ ] `npm run dev` → visit `/`: confirm new palette, tight radii, inline icons, live Playground pill in nav, rebuilt FinalCTA, ambient grid behind hero.
- [ ] Resize to 390px width: navbar shows brand + hamburger only; hero H1 wraps; drawer opens with 5 nav links + 3 stacked CTAs.
- [ ] `npm run build` → confirm `tsc`, `vite build`, and `prerender` all pass and the marketing prerenders pick up the new tokens.
- [ ] `npm run validate:blogs` to confirm the table-style update in `src/index.css` didn't regress blog SEO validation.

## Out of scope (follow-ups noted in #18)
- Kubernetes preview SVG inside Features still has internal purple chrome.
- MLOps training-loss chart retains a single purple→indigo gradient stroke as the lone chart accent.