### PR TITLE
Point Playground links to demo.alertmend.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,6 @@ const metaDescription = generateUniqueMetaDescription(
 ## 🔗 Links
 
 - **Website:** https://alertmend.io
-- **Playground:** https://app.alertmend.io/playground
+- **Playground:** https://demo.alertmend.io
 - **Book a Demo:** https://calendly.com/hello-alertmend/30min
 - **Signup:** https://app.alertmend.io/signup

--- a/SALES.md
+++ b/SALES.md
@@ -154,7 +154,7 @@ Use these as anchors in a deal:
 
 - **Free cluster health check.** A read-only scan of a live cluster. Output: prioritized list of OOM-trending workloads, restart-prone pods, misconfigured limits, over-provisioned spend, unowned alerts. No incident required, results in minutes.
 - **Live in 1 day.** No tool replacement required, no credit card.
-- **[Book a demo](https://calendly.com/hello-alertmend/30min)** · **[Try the playground](https://app.alertmend.io/playground?source=homepage)** · **[Sign up](https://app.alertmend.io/signup)**
+- **[Book a demo](https://calendly.com/hello-alertmend/30min)** · **[Try the playground](https://demo.alertmend.io?source=homepage)** · **[Sign up](https://app.alertmend.io/signup)**
 
 ---
 

--- a/scripts/build-blog-html.js
+++ b/scripts/build-blog-html.js
@@ -757,10 +757,10 @@ markdownFiles.forEach(file => {
     signupTrackingUrlObj.searchParams.set('blog_slug', normalizedBlogSlug)
     const signupTrackingUrl = signupTrackingUrlObj.toString()
 
-    const playgroundTrackingUrlObj = new URL('https://app.alertmend.io/playground')
-    playgroundTrackingUrlObj.searchParams.set('source', blogSourceParam)
-    playgroundTrackingUrlObj.searchParams.set('blog_slug', normalizedBlogSlug)
-    const playgroundTrackingUrl = playgroundTrackingUrlObj.toString()
+    const playgroundTrackingUrl = 'https://demo.alertmend.io'
+    
+    
+    
 
     const calendlyTrackingUrlObj = new URL('https://calendly.com/hello-alertmend/30min')
     calendlyTrackingUrlObj.searchParams.set('source', blogSourceParam)

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -35,7 +35,7 @@ const primaryLinks: Array<
 ];
 
 const SIGNUP_URL = 'https://app.alertmend.io/signup';
-const PLAYGROUND_URL = 'https://app.alertmend.io/playground?source=homepage';
+const PLAYGROUND_URL = 'https://demo.alertmend.io';
 const CALENDLY_URL = 'https://calendly.com/hello-alertmend/30min';
 
 export default function Nav() {

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -7,7 +7,7 @@ const CALENDLY_URL = 'https://calendly.com/hello-alertmend/30min';
  *  offers both a high-touch path (Book a demo) and a low-touch path (free
  *  trial), the way Datadog/Linear/Vercel split traffic by intent. */
 const SIGNUP_URL = 'https://app.alertmend.io/signup?source=homepage-hero';
-const PLAYGROUND_URL = 'https://app.alertmend.io/playground?source=homepage';
+const PLAYGROUND_URL = 'https://demo.alertmend.io';
 
 /** Detects the user's reduced-motion preference so we can suppress
  *  autoplay for motion-sensitive visitors. They still get the poster


### PR DESCRIPTION
## Summary
- Update nav and hero Playground buttons to `https://demo.alertmend.io`
- Update blog HTML generator to use the same URL (no `/playground` path)
- Refresh README and SALES docs

## Test plan
- [ ] Click Playground in homepage nav → opens `https://demo.alertmend.io`
- [ ] Click Playground on a blog post → opens `https://demo.alertmend.io`
- [ ] Redeploy site after merge


Made with [Cursor](https://cursor.com)